### PR TITLE
Fix password masking in migration URL

### DIFF
--- a/src/pq/client.py
+++ b/src/pq/client.py
@@ -87,7 +87,9 @@ class PQ:
 
         alembic_cfg = Config()
         alembic_cfg.set_main_option("script_location", migrations_dir)
-        alembic_cfg.set_main_option("sqlalchemy.url", str(self._engine.url))
+        alembic_cfg.set_main_option(
+            "sqlalchemy.url", self._engine.url.render_as_string(hide_password=False)
+        )
         command.upgrade(alembic_cfg, "head")
 
     def create_tables(self) -> None:


### PR DESCRIPTION
## Summary
- Fix bug where `str(engine.url)` masks password as `***`, causing Alembic to fail authentication
- Use `render_as_string(hide_password=False)` to preserve actual password for database connections

## Test plan
- [x] All 70 tests pass
- [x] Linting and type checking pass