### PR TITLE
test: add coverage for upsert() and lifecycle hooks

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -284,3 +284,162 @@ class TestClientId:
 
         assert task_id_1 != task_id_2
         assert pq.pending_count() == 2
+
+
+def upsert_handler(value: int = 0) -> None:
+    """Handler for upsert tests."""
+    pass
+
+
+def failing_upsert_handler() -> None:
+    """Failing handler for upsert tests."""
+    raise ValueError("boom")
+
+
+class TestUpsert:
+    """Tests for upsert method."""
+
+    def test_upsert_creates_new_task(self, pq: PQ) -> None:
+        """Upsert creates a new task when client_id doesn't exist."""
+        task_id = pq.upsert(upsert_handler, value=42, client_id="new-task")
+
+        assert task_id is not None
+        assert pq.pending_count() == 1
+
+        task = pq.get_task_by_client_id("new-task")
+        assert task is not None
+        assert task.id == task_id
+        assert task.payload["kwargs"] == {"value": 42}
+
+    def test_upsert_updates_existing_task(self, pq: PQ) -> None:
+        """Upsert updates task when client_id already exists."""
+        # Create initial task
+        task_id_1 = pq.upsert(upsert_handler, value=1, client_id="my-task")
+
+        # Upsert with same client_id
+        task_id_2 = pq.upsert(upsert_handler, value=2, client_id="my-task")
+
+        # Should still have only 1 task
+        assert pq.pending_count() == 1
+        # Should return the same task ID
+        assert task_id_1 == task_id_2
+
+        task = pq.get_task_by_client_id("my-task")
+        assert task is not None
+        # Should have updated payload
+        assert task.payload["kwargs"] == {"value": 2}
+
+    def test_upsert_resets_status_to_pending(self, pq: PQ) -> None:
+        """Upsert resets status to PENDING on conflict."""
+        from pq.models import TaskStatus
+
+        # Create and process task
+        pq.upsert(dummy_handler, client_id="reset-test")
+        pq.run_worker_once()
+
+        # Task should be completed
+        task = pq.get_task_by_client_id("reset-test")
+        assert task is not None
+        assert task.status == TaskStatus.COMPLETED
+
+        # Upsert same client_id
+        pq.upsert(dummy_handler, client_id="reset-test")
+
+        # Status should be reset to PENDING
+        task = pq.get_task_by_client_id("reset-test")
+        assert task is not None
+        assert task.status == TaskStatus.PENDING
+
+    def test_upsert_resets_attempts_to_zero(self, pq: PQ) -> None:
+        """Upsert resets attempts to 0 on conflict."""
+        # Create and process task
+        pq.upsert(dummy_handler, client_id="attempts-test")
+        pq.run_worker_once()
+
+        task = pq.get_task_by_client_id("attempts-test")
+        assert task is not None
+        assert task.attempts == 1
+
+        # Upsert same client_id
+        pq.upsert(dummy_handler, client_id="attempts-test")
+
+        task = pq.get_task_by_client_id("attempts-test")
+        assert task is not None
+        assert task.attempts == 0
+
+    def test_upsert_clears_timestamps(self, pq: PQ) -> None:
+        """Upsert clears started_at and completed_at on conflict."""
+        # Create and process task
+        pq.upsert(dummy_handler, client_id="timestamps-test")
+        pq.run_worker_once()
+
+        task = pq.get_task_by_client_id("timestamps-test")
+        assert task is not None
+        assert task.started_at is not None
+        assert task.completed_at is not None
+
+        # Upsert same client_id
+        pq.upsert(dummy_handler, client_id="timestamps-test")
+
+        task = pq.get_task_by_client_id("timestamps-test")
+        assert task is not None
+        assert task.started_at is None
+        assert task.completed_at is None
+
+    def test_upsert_clears_error(self, pq: PQ) -> None:
+        """Upsert clears error field on conflict."""
+        from pq.models import TaskStatus
+
+        pq.upsert(failing_upsert_handler, client_id="error-test")
+        pq.run_worker_once()
+
+        task = pq.get_task_by_client_id("error-test")
+        assert task is not None
+        assert task.status == TaskStatus.FAILED
+        assert task.error is not None
+
+        # Upsert same client_id with different handler
+        pq.upsert(dummy_handler, client_id="error-test")
+
+        task = pq.get_task_by_client_id("error-test")
+        assert task is not None
+        assert task.error is None
+
+    def test_upsert_updates_priority(self, pq: PQ) -> None:
+        """Upsert updates priority on conflict."""
+        from pq.priority import Priority
+
+        pq.upsert(dummy_handler, client_id="priority-test", priority=Priority.LOW)
+
+        task = pq.get_task_by_client_id("priority-test")
+        assert task is not None
+        assert task.priority == Priority.LOW.value
+
+        pq.upsert(dummy_handler, client_id="priority-test", priority=Priority.HIGH)
+
+        task = pq.get_task_by_client_id("priority-test")
+        assert task is not None
+        assert task.priority == Priority.HIGH.value
+
+    def test_upsert_updates_run_at(self, pq: PQ) -> None:
+        """Upsert updates run_at on conflict."""
+        now = datetime.now(UTC)
+        future = now + timedelta(hours=2)
+
+        pq.upsert(dummy_handler, client_id="run-at-test", run_at=now)
+
+        task = pq.get_task_by_client_id("run-at-test")
+        assert task is not None
+        assert abs((task.run_at - now).total_seconds()) < 1
+
+        pq.upsert(dummy_handler, client_id="run-at-test", run_at=future)
+
+        task = pq.get_task_by_client_id("run-at-test")
+        assert task is not None
+        assert abs((task.run_at - future).total_seconds()) < 1
+
+    def test_upsert_returns_int_id(self, pq: PQ) -> None:
+        """Upsert returns an integer ID."""
+        task_id = pq.upsert(dummy_handler, client_id="int-test")
+        assert isinstance(task_id, int)
+        assert task_id > 0

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -402,6 +402,190 @@ class TestAsyncTasks:
         assert pq.pending_count() == 0
 
 
+class TestHooks:
+    """Tests for pre_execute/post_execute hooks."""
+
+    def test_pre_execute_hook_called_for_one_off_task(
+        self, pq: PQ, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """Pre-execute hook is called before one-off task execution."""
+        results = manager.list()
+        _set_shared_results(results)
+
+        def pre_hook(task: Any) -> None:
+            _shared_results.append(("pre", task.name))
+
+        pq.enqueue(noop_handler)
+
+        from pq.worker import run_worker_once
+
+        run_worker_once(pq, pre_execute=pre_hook)
+
+        assert len(results) == 1
+        assert results[0][0] == "pre"
+        assert "noop_handler" in results[0][1]
+
+    def test_post_execute_hook_called_for_one_off_task(
+        self, pq: PQ, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """Post-execute hook is called after one-off task execution."""
+        results = manager.list()
+        _set_shared_results(results)
+
+        def post_hook(task: Any, error: Exception | None) -> None:
+            _shared_results.append(("post", task.name, error))
+
+        pq.enqueue(noop_handler)
+
+        from pq.worker import run_worker_once
+
+        run_worker_once(pq, post_execute=post_hook)
+
+        assert len(results) == 1
+        assert results[0][0] == "post"
+        assert "noop_handler" in results[0][1]
+        assert results[0][2] is None  # No error
+
+    def test_post_execute_hook_receives_error_on_failure(
+        self, pq: PQ, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """Post-execute hook receives error when task fails."""
+        results = manager.list()
+        _set_shared_results(results)
+
+        def post_hook(task: Any, error: Exception | None) -> None:
+            _shared_results.append(
+                ("post", error is not None, str(error) if error else None)
+            )
+
+        pq.enqueue(failing_handler)
+
+        from pq.worker import run_worker_once
+
+        run_worker_once(pq, post_execute=post_hook)
+
+        assert len(results) == 1
+        assert results[0][0] == "post"
+        assert results[0][1] is True  # Had error
+        assert "boom" in results[0][2]  # Error message contains "boom"
+
+    def test_pre_execute_hook_called_for_periodic_task(
+        self, pq: PQ, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """Pre-execute hook is called before periodic task execution."""
+        results = manager.list()
+        _set_shared_results(results)
+
+        def pre_hook(task: Any) -> None:
+            _shared_results.append(("pre", task.name))
+
+        pq.schedule(periodic_noop_handler, run_every=timedelta(hours=1))
+
+        from pq.worker import run_worker_once
+
+        run_worker_once(pq, pre_execute=pre_hook)
+
+        assert len(results) == 1
+        assert results[0][0] == "pre"
+        assert "periodic_noop_handler" in results[0][1]
+
+    def test_post_execute_hook_called_for_periodic_task(
+        self, pq: PQ, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """Post-execute hook is called after periodic task execution."""
+        results = manager.list()
+        _set_shared_results(results)
+
+        def post_hook(task: Any, error: Exception | None) -> None:
+            _shared_results.append(("post", task.name, error))
+
+        pq.schedule(periodic_noop_handler, run_every=timedelta(hours=1))
+
+        from pq.worker import run_worker_once
+
+        run_worker_once(pq, post_execute=post_hook)
+
+        assert len(results) == 1
+        assert results[0][0] == "post"
+        assert "periodic_noop_handler" in results[0][1]
+        assert results[0][2] is None  # No error
+
+    def test_both_hooks_called_in_order(
+        self, pq: PQ, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """Pre and post hooks are called in correct order."""
+        results = manager.list()
+        _set_shared_results(results)
+
+        def pre_hook(task: Any) -> None:
+            _shared_results.append("pre")
+
+        def post_hook(task: Any, error: Exception | None) -> None:
+            _shared_results.append("post")
+
+        pq.enqueue(noop_handler)
+
+        from pq.worker import run_worker_once
+
+        run_worker_once(pq, pre_execute=pre_hook, post_execute=post_hook)
+
+        assert list(results) == ["pre", "post"]
+
+    def test_hook_receives_task_object_with_correct_fields(
+        self, pq: PQ, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """Hooks receive task object with expected fields."""
+        results = manager.list()
+        _set_shared_results(results)
+
+        def pre_hook(task: Any) -> None:
+            _shared_results.append(
+                {
+                    "has_id": hasattr(task, "id"),
+                    "has_name": hasattr(task, "name"),
+                    "has_payload": hasattr(task, "payload"),
+                    "has_client_id": hasattr(task, "client_id"),
+                }
+            )
+
+        pq.enqueue(noop_handler, client_id="hook-test")
+
+        from pq.worker import run_worker_once
+
+        run_worker_once(pq, pre_execute=pre_hook)
+
+        assert len(results) == 1
+        task_info = results[0]
+        assert task_info["has_id"] is True
+        assert task_info["has_name"] is True
+        assert task_info["has_payload"] is True
+        assert task_info["has_client_id"] is True
+
+    def test_post_execute_called_even_when_pre_execute_fails(
+        self, pq: PQ, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """Post-execute hook is called even if pre-execute hook raises."""
+        results = manager.list()
+        _set_shared_results(results)
+
+        def pre_hook(task: Any) -> None:
+            _shared_results.append("pre")
+            raise RuntimeError("pre hook failed")
+
+        def post_hook(task: Any, error: Exception | None) -> None:
+            _shared_results.append("post")
+
+        pq.enqueue(noop_handler)
+
+        from pq.worker import run_worker_once
+
+        run_worker_once(pq, pre_execute=pre_hook, post_execute=post_hook)
+
+        # Both should be called (post catches the pre-hook error)
+        assert "pre" in results
+        assert "post" in results
+
+
 class TestTaskTimeout:
     """Tests for task timeout functionality."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -719,7 +719,7 @@ wheels = [
 
 [[package]]
 name = "python-pq"
-version = "0.3.4"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
Add 17 tests for features introduced in PR #11 (feat/upsert and callbacks).

**upsert() tests (9):**
- Creates new task when client_id doesn't exist
- Updates task on client_id conflict
- Resets status, attempts, timestamps, error on conflict
- Updates priority and run_at on conflict

**pre_execute/post_execute hook tests (8):**
- Hooks called for one-off and periodic tasks
- Post hook receives error on task failure
- Hooks called in correct order
- Post hook called even if pre hook raises

## Test plan
- [x] All 87 tests pass
- [x] Linting and type checking pass