### PR TITLE
Add `active` column to periodic tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,20 @@ pq.schedule(fast_idempotent_task, run_every=timedelta(seconds=30), max_concurren
 
 The lock auto-expires after `max_runtime` seconds (or 1 hour by default) for crash safety.
 
+### Pausing & Resuming
+
+Disable a periodic task without removing it:
+
+```python
+# Pause - task stays in the database but won't run
+pq.schedule(sync_inventory, run_every=timedelta(minutes=5), active=False)
+
+# Resume
+pq.schedule(sync_inventory, run_every=timedelta(minutes=5), active=True)
+```
+
+New schedules are active by default.
+
 ### Multiple Schedules (Key)
 
 Use `key` to register the same function multiple times with different configurations:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,6 +70,7 @@ pq.schedule(cleanup, run_every=timedelta(hours=1))
 | `priority` | 0-100, higher runs first |
 | `run_every` | Interval (e.g., 1 hour) |
 | `cron` | Cron expression (e.g., `0 9 * * 1`) |
+| `active` | Whether the task is executed (default `true`) |
 | `next_run` | Next scheduled execution |
 
 ## Fork Isolation

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -52,6 +52,29 @@ pq.unschedule(sync_data, key="us")
 pq.unschedule(heartbeat)
 ```
 
+## Pausing & Resuming Periodic Tasks
+
+Disable a periodic task without removing it, then re-enable it later:
+
+```python
+from datetime import timedelta
+from pq import PQ
+
+pq = PQ("postgresql://localhost/mydb")
+
+def sync_inventory() -> None:
+    print("syncing...")
+
+# Schedule as usual (active by default)
+pq.schedule(sync_inventory, run_every=timedelta(minutes=5))
+
+# Pause - keeps the schedule but the worker won't run it
+pq.schedule(sync_inventory, run_every=timedelta(minutes=5), active=False)
+
+# Resume
+pq.schedule(sync_inventory, run_every=timedelta(minutes=5), active=True)
+```
+
 ## Priority Queues
 
 [`examples/priority.py`](https://github.com/ricwo/pq/blob/main/examples/priority.py) - Task prioritization.

--- a/src/pq/client.py
+++ b/src/pq/client.py
@@ -237,6 +237,7 @@ class PQ:
         client_id: str | None = None,
         max_concurrent: int | None = 1,
         key: str = "",
+        active: bool = True,
         **kwargs: Any,
     ) -> int:
         """Schedule a periodic task.
@@ -256,6 +257,8 @@ class PQ:
                 for future use and raise ValueError.
             key: Discriminator for multiple schedules of the same function.
                 Defaults to "" (empty string).
+            active: Whether the task is active. Inactive tasks are not executed.
+                Defaults to True.
             **kwargs: Keyword arguments to pass to the handler.
 
         Returns:
@@ -316,6 +319,7 @@ class PQ:
                     next_run=next_run,
                     client_id=client_id,
                     max_concurrent=max_concurrent,
+                    active=active,
                 )
                 .on_conflict_do_update(
                     index_elements=["name", "key"],
@@ -326,6 +330,7 @@ class PQ:
                         "cron": cron_expr,
                         "next_run": next_run,
                         "max_concurrent": max_concurrent,
+                        "active": active,
                     },
                 )
                 .returning(Periodic.id)

--- a/src/pq/migrations/versions/20260217T120000Z_c3d4e5f6a7b8_add_periodic_active.py
+++ b/src/pq/migrations/versions/20260217T120000Z_c3d4e5f6a7b8_add_periodic_active.py
@@ -1,0 +1,32 @@
+"""add periodic active
+
+Revision ID: c3d4e5f6a7b8
+Revises: b7c8d9e0f1a2
+Create Date: 2026-02-17 12:00:00 Z
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c3d4e5f6a7b8"
+down_revision: Union[str, Sequence[str], None] = "b7c8d9e0f1a2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add active column to pq_periodic."""
+    op.add_column(
+        "pq_periodic",
+        sa.Column("active", sa.Boolean(), nullable=False, server_default="true"),
+    )
+
+
+def downgrade() -> None:
+    """Remove active column from pq_periodic."""
+    op.drop_column("pq_periodic", "active")

--- a/src/pq/models.py
+++ b/src/pq/models.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from sqlalchemy import (
     BigInteger,
+    Boolean,
     DateTime,
     Enum,
     Identity,
@@ -92,6 +93,7 @@ class Periodic(Base):
     cron: Mapped[str | None] = mapped_column(String(100), nullable=True)
     next_run: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     max_concurrent: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
     last_run: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )

--- a/src/pq/worker.py
+++ b/src/pq/worker.py
@@ -560,6 +560,7 @@ def _process_periodic_task(
             # Claim highest priority due periodic task with FOR UPDATE SKIP LOCKED
             # Filter out tasks that are locked (max_concurrent=1 and locked_until in future)
             stmt = select(Periodic).where(
+                Periodic.active.is_(True),
                 Periodic.next_run <= func.now(),
                 or_(
                     Periodic.max_concurrent.is_(None),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -232,6 +232,72 @@ class TestScheduleMaxConcurrent:
             assert periodic.max_concurrent == 1
 
 
+class TestScheduleActive:
+    """Tests for active parameter in schedule."""
+
+    def test_schedule_active_defaults_true(self, pq: PQ) -> None:
+        """Schedule stores active=True by default."""
+        from sqlalchemy import select
+
+        pq.schedule(cleanup_handler, run_every=timedelta(hours=1))
+
+        with pq.session() as session:
+            periodic = session.execute(
+                select(Periodic).where(
+                    Periodic.name == "tests.test_client:cleanup_handler"
+                )
+            ).scalar_one()
+            assert periodic.active is True
+
+    def test_schedule_active_false(self, pq: PQ) -> None:
+        """Schedule stores active=False when explicitly set."""
+        from sqlalchemy import select
+
+        pq.schedule(cleanup_handler, run_every=timedelta(hours=1), active=False)
+
+        with pq.session() as session:
+            periodic = session.execute(
+                select(Periodic).where(
+                    Periodic.name == "tests.test_client:cleanup_handler"
+                )
+            ).scalar_one()
+            assert periodic.active is False
+
+    def test_schedule_upserts_active(self, pq: PQ) -> None:
+        """Schedule upsert updates active flag."""
+        from sqlalchemy import select
+
+        pq.schedule(cleanup_handler, run_every=timedelta(hours=1), active=True)
+        pq.schedule(cleanup_handler, run_every=timedelta(hours=1), active=False)
+
+        assert pq.periodic_count() == 1
+
+        with pq.session() as session:
+            periodic = session.execute(
+                select(Periodic).where(
+                    Periodic.name == "tests.test_client:cleanup_handler"
+                )
+            ).scalar_one()
+            assert periodic.active is False
+
+    def test_schedule_upserts_active_reactivate(self, pq: PQ) -> None:
+        """Schedule upsert can re-enable an inactive task."""
+        from sqlalchemy import select
+
+        pq.schedule(cleanup_handler, run_every=timedelta(hours=1), active=False)
+        pq.schedule(cleanup_handler, run_every=timedelta(hours=1), active=True)
+
+        assert pq.periodic_count() == 1
+
+        with pq.session() as session:
+            periodic = session.execute(
+                select(Periodic).where(
+                    Periodic.name == "tests.test_client:cleanup_handler"
+                )
+            ).scalar_one()
+            assert periodic.active is True
+
+
 class TestPeriodicKey:
     """Tests for periodic task key discriminator."""
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -361,6 +361,44 @@ class TestPeriodicTasks:
         assert len(count) == 1
 
 
+class TestActiveFlag:
+    """Tests for active flag on periodic tasks."""
+
+    def test_inactive_periodic_not_executed(self, pq: PQ) -> None:
+        """Worker skips inactive periodic tasks."""
+        pq.schedule(periodic_noop_handler, run_every=timedelta(seconds=0), active=False)
+
+        processed = pq.run_worker_once()
+        assert processed is False
+
+    def test_active_periodic_executed(
+        self, pq: PQ, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """Worker executes active periodic tasks normally."""
+        results = manager.list()
+        _set_shared_results(results)
+
+        pq.schedule(counter_handler, run_every=timedelta(seconds=0), active=True)
+
+        processed = pq.run_worker_once()
+        assert processed is True
+        assert len(results) == 1
+
+    def test_reactivated_periodic_executed(
+        self, pq: PQ, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """Worker executes a periodic task after re-activation."""
+        results = manager.list()
+        _set_shared_results(results)
+
+        pq.schedule(counter_handler, run_every=timedelta(seconds=0), active=False)
+        assert pq.run_worker_once() is False
+
+        pq.schedule(counter_handler, run_every=timedelta(seconds=0), active=True)
+        assert pq.run_worker_once() is True
+        assert len(results) == 1
+
+
 class TestMaxConcurrent:
     """Tests for max_concurrent periodic task behavior."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -722,7 +722,7 @@ wheels = [
 
 [[package]]
 name = "python-pq"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- Adds an `active` boolean column (default `true`) to the `pq_periodic` table so periodic tasks can be paused and resumed without removing them
- The worker filters on `active = true`, so inactive tasks are skipped
- `pq.schedule()` accepts `active=True/False` and upserts it on conflict

## Test plan

- [x] `TestScheduleActive` in `test_client.py` — default true, explicit false, upsert toggle both directions
- [x] `TestActiveFlag` in `test_worker.py` — inactive skipped, active executed, re-activated executed
- [x] All 109 tests pass
- [x] Ruff lint, ruff format, ty check all pass