### PR TITLE
feat: concurrent task execution (concurrency parameter)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-pq"
-version = "0.6.2"
+version = "0.6.3"
 description = "Postgres-backed job queue for Python"
 readme = "README.md"
 authors = [

--- a/src/pq/__init__.py
+++ b/src/pq/__init__.py
@@ -5,7 +5,7 @@ from pq.models import Periodic, Task, TaskStatus
 from pq.priority import Priority
 from pq.worker import PostExecuteHook, PreExecuteHook, TaskTimeoutError
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 
 __all__ = [
     "PQ",

--- a/src/pq/client.py
+++ b/src/pq/client.py
@@ -510,6 +510,7 @@ class PQ:
     def run_worker(
         self,
         *,
+        concurrency: int = 1,
         poll_interval: float = 1.0,
         max_runtime: float = 30 * 60,
         priorities: Set[Priority] | None = None,
@@ -519,6 +520,8 @@ class PQ:
         Each task executes in a forked child process for memory isolation.
 
         Args:
+            concurrency: Maximum number of tasks to process simultaneously.
+                Default: 1 (sequential processing).
             poll_interval: Seconds to sleep between polls when idle.
             max_runtime: Maximum execution time per task in seconds. Default: 30 min.
             priorities: If set, only process tasks with these priority levels.
@@ -528,6 +531,7 @@ class PQ:
 
         run_worker(
             self,
+            concurrency=concurrency,
             poll_interval=poll_interval,
             max_runtime=max_runtime,
             priorities=priorities,

--- a/src/pq/worker.py
+++ b/src/pq/worker.py
@@ -283,7 +283,7 @@ def _wait_for_child(child_pid: int, read_fd: int) -> _ChildResult:
                 TaskStatus.FAILED, "Task exceeded max runtime", "timeout"
             )
         if error_msg:
-            return _ChildResult(TaskStatus.FAILED, error_msg.split("\n")[0], "error")
+            return _ChildResult(TaskStatus.FAILED, error_msg.rstrip(), "error")
         return _ChildResult(
             TaskStatus.FAILED,
             f"Task failed with exit code {exit_code}",

--- a/src/pq/worker.py
+++ b/src/pq/worker.py
@@ -9,12 +9,14 @@ from __future__ import annotations
 import asyncio
 import inspect
 import os
+import select as select_module
 import signal
 import sys
 import time
 import traceback
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, NamedTuple, Protocol
 
 from croniter import croniter
 from loguru import logger
@@ -77,6 +79,27 @@ DEFAULT_CLEANUP_INTERVAL: float = 3600
 EXIT_SUCCESS = 0
 EXIT_FAILURE = 1
 EXIT_TIMEOUT = 124  # Like GNU timeout
+
+
+class _ChildResult(NamedTuple):
+    """Result from waiting for a forked child process."""
+
+    task_status: TaskStatus
+    error_msg: str | None
+    exit_kind: str  # "success", "timeout", "oom", "killed", "error"
+
+
+@dataclass
+class _ChildSlot:
+    """Tracks a running forked child in concurrent mode."""
+
+    pid: int
+    read_fd: int
+    task_id: int
+    name: str
+    start_time: float
+    is_periodic: bool
+    periodic_max_concurrent: int | None = None
 
 
 class WorkerError(Exception):
@@ -169,6 +192,107 @@ def _run_in_child(
         os._exit(EXIT_FAILURE)
 
 
+def _fork_child(
+    handler: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    *,
+    max_runtime: float,
+    task: Task | Periodic,
+    pre_execute: PreExecuteHook | None = None,
+    post_execute: PostExecuteHook | None = None,
+) -> tuple[int, int]:
+    """Fork a child process to execute the handler.
+
+    Returns:
+        Tuple of (child_pid, read_fd) for monitoring the child.
+    """
+    read_fd, write_fd = os.pipe()
+    child_pid = os.fork()
+
+    if child_pid == 0:
+        # === CHILD PROCESS ===
+        os.close(read_fd)
+        _run_in_child(
+            handler,
+            args,
+            kwargs,
+            max_runtime,
+            write_fd,
+            task,
+            pre_execute,
+            post_execute,
+        )
+        os._exit(EXIT_FAILURE)  # _run_in_child never returns, but just in case
+
+    # === PARENT PROCESS ===
+    os.close(write_fd)
+    return child_pid, read_fd
+
+
+def _wait_for_child(child_pid: int, read_fd: int) -> _ChildResult:
+    """Wait for a forked child process and return the result.
+
+    Args:
+        child_pid: PID of the child process.
+        read_fd: Read end of the error pipe.
+
+    Returns:
+        _ChildResult with task status, error message, and exit kind.
+    """
+    _, raw_status, rusage = os.wait4(child_pid, 0)
+
+    # Read error message from pipe
+    error_bytes = b""
+    try:
+        while True:
+            chunk = os.read(read_fd, 4096)
+            if not chunk:
+                break
+            error_bytes += chunk
+    except Exception:
+        pass
+    finally:
+        os.close(read_fd)
+
+    error_msg = error_bytes.decode("utf-8", errors="replace") if error_bytes else ""
+
+    if os.WIFSIGNALED(raw_status):
+        signal_num = os.WTERMSIG(raw_status)
+        if signal_num == signal.SIGKILL:
+            max_rss_kb = rusage.ru_maxrss
+            if sys.platform == "darwin":
+                max_rss_kb = max_rss_kb // 1024
+            return _ChildResult(
+                TaskStatus.FAILED,
+                f"Task killed (likely OOM). Max RSS: {max_rss_kb} KB",
+                "oom",
+            )
+        return _ChildResult(
+            TaskStatus.FAILED,
+            f"Task killed by signal {signal_num}",
+            "killed",
+        )
+
+    if os.WIFEXITED(raw_status):
+        exit_code = os.WEXITSTATUS(raw_status)
+        if exit_code == EXIT_SUCCESS:
+            return _ChildResult(TaskStatus.COMPLETED, None, "success")
+        if exit_code == EXIT_TIMEOUT:
+            return _ChildResult(
+                TaskStatus.FAILED, "Task exceeded max runtime", "timeout"
+            )
+        if error_msg:
+            return _ChildResult(TaskStatus.FAILED, error_msg.split("\n")[0], "error")
+        return _ChildResult(
+            TaskStatus.FAILED,
+            f"Task failed with exit code {exit_code}",
+            "error",
+        )
+
+    return _ChildResult(TaskStatus.FAILED, "Unknown child exit status", "error")
+
+
 def _execute_in_fork(
     handler: Callable[..., Any],
     args: tuple[Any, ...],
@@ -200,76 +324,26 @@ def _execute_in_fork(
         TaskKilledError: If task is killed by another signal.
         Exception: If task raises an exception.
     """
-    # Create pipe for error message communication
-    read_fd, write_fd = os.pipe()
+    child_pid, read_fd = _fork_child(
+        handler,
+        args,
+        kwargs,
+        max_runtime=max_runtime,
+        task=task,
+        pre_execute=pre_execute,
+        post_execute=post_execute,
+    )
+    result = _wait_for_child(child_pid, read_fd)
 
-    child_pid = os.fork()
-
-    if child_pid == 0:
-        # === CHILD PROCESS ===
-        os.close(read_fd)
-        _run_in_child(
-            handler,
-            args,
-            kwargs,
-            max_runtime,
-            write_fd,
-            task,
-            pre_execute,
-            post_execute,
-        )
-        # _run_in_child never returns, but just in case:
-        os._exit(EXIT_FAILURE)
-
-    else:
-        # === PARENT PROCESS ===
-        os.close(write_fd)
-
-        # Wait for child to finish
-        _, status, rusage = os.wait4(child_pid, 0)
-
-        # Read any error message from child
-        error_bytes = b""
-        try:
-            while True:
-                chunk = os.read(read_fd, 4096)
-                if not chunk:
-                    break
-                error_bytes += chunk
-        except Exception:
-            pass
-        finally:
-            os.close(read_fd)
-
-        error_msg = error_bytes.decode("utf-8", errors="replace") if error_bytes else ""
-
-        # Check how child exited
-        if os.WIFSIGNALED(status):
-            signal_num = os.WTERMSIG(status)
-            if signal_num == signal.SIGKILL:
-                # SIGKILL (9) often means OOM killer
-                # ru_maxrss is in KB on Linux, bytes on macOS
-                max_rss_kb = rusage.ru_maxrss
-                if sys.platform == "darwin":
-                    max_rss_kb = max_rss_kb // 1024
-                raise TaskOOMError(
-                    f"Task killed (likely OOM). Max RSS: {max_rss_kb} KB"
-                )
-            else:
-                raise TaskKilledError(f"Task killed by signal {signal_num}")
-
-        elif os.WIFEXITED(status):
-            exit_code = os.WEXITSTATUS(status)
-            if exit_code == EXIT_SUCCESS:
-                return  # Success!
-            elif exit_code == EXIT_TIMEOUT:
-                raise TaskTimeoutError("Task exceeded max runtime")
-            else:
-                # Task raised an exception
-                if error_msg:
-                    raise Exception(error_msg.split("\n")[0])  # First line
-                else:
-                    raise Exception(f"Task failed with exit code {exit_code}")
+    if result.exit_kind == "success":
+        return
+    if result.exit_kind == "timeout":
+        raise TaskTimeoutError(result.error_msg or "Task exceeded max runtime")
+    if result.exit_kind == "oom":
+        raise TaskOOMError(result.error_msg or "Task killed (likely OOM)")
+    if result.exit_kind == "killed":
+        raise TaskKilledError(result.error_msg or "Task killed by signal")
+    raise Exception(result.error_msg or "Task failed")
 
 
 def _maybe_run_cleanup(
@@ -306,6 +380,7 @@ def _maybe_run_cleanup(
 def run_worker(
     pq: PQ,
     *,
+    concurrency: int = 1,
     poll_interval: float = 1.0,
     max_runtime: float = DEFAULT_MAX_RUNTIME,
     priorities: Set[Priority] | None = None,
@@ -320,6 +395,8 @@ def run_worker(
 
     Args:
         pq: PQ client instance.
+        concurrency: Maximum number of tasks to process simultaneously.
+            Default: 1 (sequential processing).
         poll_interval: Seconds to sleep between polls when idle.
         max_runtime: Maximum execution time per task in seconds. Default: 30 min.
         priorities: If set, only process tasks with these priority levels.
@@ -334,9 +411,29 @@ def run_worker(
     """
     if priorities:
         priority_names = ", ".join(p.name for p in sorted(priorities, reverse=True))
-        logger.info(f"Starting PQ worker (priorities: {priority_names})...")
+        logger.info(
+            f"Starting PQ worker (priorities: {priority_names},"
+            f" concurrency: {concurrency})..."
+        )
     else:
-        logger.info("Starting PQ worker (fork isolation enabled)...")
+        logger.info(
+            f"Starting PQ worker (concurrency: {concurrency},"
+            " fork isolation enabled)..."
+        )
+
+    if concurrency > 1:
+        _run_concurrent(
+            pq,
+            concurrency=concurrency,
+            poll_interval=poll_interval,
+            max_runtime=max_runtime,
+            priorities=priorities,
+            pre_execute=pre_execute,
+            post_execute=post_execute,
+            retention_days=retention_days,
+            cleanup_interval=cleanup_interval,
+        )
+        return
 
     last_cleanup: list[float] = [0.0]  # Mutable container for tracking
 
@@ -653,3 +750,356 @@ def _process_periodic_task(
                 logger.error(f"Failed to clear lock for periodic task '{name}': {e}")
 
     return True
+
+
+# --- Concurrent worker functions ---
+
+
+def _claim_and_fork_one_off(
+    pq: PQ,
+    *,
+    max_runtime: float,
+    priorities: Set[Priority] | None = None,
+    pre_execute: PreExecuteHook | None = None,
+    post_execute: PostExecuteHook | None = None,
+) -> _ChildSlot | None:
+    """Claim a one-off task and fork a child to execute it.
+
+    Returns:
+        _ChildSlot if a task was claimed and forked, None if no tasks available.
+    """
+    try:
+        with pq.session() as session:
+            stmt = (
+                select(Task)
+                .where(Task.status == TaskStatus.PENDING)
+                .where(Task.run_at <= func.now())
+            )
+            if priorities:
+                stmt = stmt.where(Task.priority.in_([p.value for p in priorities]))
+            stmt = (
+                stmt.order_by(Task.priority.desc(), Task.run_at)
+                .with_for_update(skip_locked=True)
+                .limit(1)
+            )
+            task = session.execute(stmt).scalar_one_or_none()
+
+            if task is None:
+                return None
+
+            task.status = TaskStatus.RUNNING
+            task.started_at = datetime.now(UTC)
+            task.attempts += 1
+
+            name = task.name
+            payload = task.payload
+            task_id = task.id
+
+            session.flush()
+            session.expunge(task)
+
+    except Exception as e:
+        logger.error(f"Error claiming task: {e}")
+        return None
+
+    try:
+        handler = resolve_function_path(name)
+        args, kwargs = deserialize(payload)
+        child_pid, read_fd = _fork_child(
+            handler,
+            args,
+            kwargs,
+            max_runtime=max_runtime,
+            task=task,
+            pre_execute=pre_execute,
+            post_execute=post_execute,
+        )
+    except Exception as e:
+        logger.error(f"Error starting task '{name}': {e}")
+        try:
+            with pq.session() as session:
+                t = session.get(Task, task_id)
+                if t:
+                    t.status = TaskStatus.FAILED
+                    t.completed_at = datetime.now(UTC)
+                    t.error = str(e)
+        except Exception as update_err:
+            logger.error(f"Error updating task status: {update_err}")
+        return None
+
+    return _ChildSlot(
+        pid=child_pid,
+        read_fd=read_fd,
+        task_id=task_id,
+        name=name,
+        start_time=time.perf_counter(),
+        is_periodic=False,
+    )
+
+
+def _claim_and_fork_periodic(
+    pq: PQ,
+    *,
+    max_runtime: float,
+    priorities: Set[Priority] | None = None,
+    pre_execute: PreExecuteHook | None = None,
+    post_execute: PostExecuteHook | None = None,
+) -> _ChildSlot | None:
+    """Claim a periodic task and fork a child to execute it.
+
+    Returns:
+        _ChildSlot if a task was claimed and forked, None if no tasks available.
+    """
+    try:
+        with pq.session() as session:
+            stmt = select(Periodic).where(
+                Periodic.active.is_(True),
+                Periodic.next_run <= func.now(),
+                or_(
+                    Periodic.max_concurrent.is_(None),
+                    Periodic.locked_until.is_(None),
+                    Periodic.locked_until <= func.now(),
+                ),
+            )
+            if priorities:
+                stmt = stmt.where(Periodic.priority.in_([p.value for p in priorities]))
+            stmt = (
+                stmt.order_by(Periodic.priority.desc(), Periodic.next_run)
+                .with_for_update(skip_locked=True)
+                .limit(1)
+            )
+            periodic = session.execute(stmt).scalar_one_or_none()
+
+            if periodic is None:
+                return None
+
+            name = periodic.name
+            payload = periodic.payload
+            periodic_id = periodic.id
+            periodic_max_concurrent = periodic.max_concurrent
+
+            if periodic.max_concurrent is not None:
+                lock_duration = max_runtime if max_runtime > 0 else 3600
+                periodic.locked_until = func.now() + timedelta(seconds=lock_duration)
+
+            periodic.last_run = func.now()
+            if periodic.cron:
+                periodic.next_run = _calculate_next_run_cron(periodic.cron)
+            else:
+                periodic.next_run = func.now() + periodic.run_every
+
+            session.flush()
+            session.expunge(periodic)
+
+    except Exception as e:
+        logger.error(f"Error claiming periodic task: {e}")
+        return None
+
+    try:
+        handler = resolve_function_path(name)
+        args, kwargs = deserialize(payload)
+        child_pid, read_fd = _fork_child(
+            handler,
+            args,
+            kwargs,
+            max_runtime=max_runtime,
+            task=periodic,
+            pre_execute=pre_execute,
+            post_execute=post_execute,
+        )
+    except Exception as e:
+        logger.error(f"Error starting periodic task '{name}': {e}")
+        if periodic_max_concurrent is not None:
+            try:
+                with pq.session() as session:
+                    session.execute(
+                        update(Periodic)
+                        .where(Periodic.id == periodic_id)
+                        .values(locked_until=None)
+                    )
+            except Exception as lock_err:
+                logger.error(
+                    f"Failed to clear lock for periodic task '{name}': {lock_err}"
+                )
+        return None
+
+    return _ChildSlot(
+        pid=child_pid,
+        read_fd=read_fd,
+        task_id=periodic_id,
+        name=name,
+        start_time=time.perf_counter(),
+        is_periodic=True,
+        periodic_max_concurrent=periodic_max_concurrent,
+    )
+
+
+def _try_claim_and_fork(
+    pq: PQ,
+    *,
+    max_runtime: float,
+    priorities: Set[Priority] | None = None,
+    pre_execute: PreExecuteHook | None = None,
+    post_execute: PostExecuteHook | None = None,
+) -> _ChildSlot | None:
+    """Try to claim any available task (one-off first, then periodic) and fork.
+
+    Returns:
+        _ChildSlot if a task was claimed and forked, None if no tasks available.
+    """
+    slot = _claim_and_fork_one_off(
+        pq,
+        max_runtime=max_runtime,
+        priorities=priorities,
+        pre_execute=pre_execute,
+        post_execute=post_execute,
+    )
+    if slot is not None:
+        return slot
+
+    return _claim_and_fork_periodic(
+        pq,
+        max_runtime=max_runtime,
+        priorities=priorities,
+        pre_execute=pre_execute,
+        post_execute=post_execute,
+    )
+
+
+def _reap_and_update(pq: PQ, slot: _ChildSlot) -> None:
+    """Wait for a forked child to finish and update task status.
+
+    Args:
+        pq: PQ client instance.
+        slot: The child slot to reap.
+    """
+    result = _wait_for_child(slot.pid, slot.read_fd)
+    elapsed = time.perf_counter() - slot.start_time
+
+    if slot.is_periodic:
+        if result.exit_kind == "success":
+            logger.debug(f"Periodic task '{slot.name}' completed in {elapsed:.3f} s")
+        elif result.exit_kind == "timeout":
+            logger.error(f"Periodic task '{slot.name}' timed out after {elapsed:.3f} s")
+        elif result.exit_kind == "oom":
+            logger.error(
+                f"Periodic task '{slot.name}' OOM after {elapsed:.3f} s:"
+                f" {result.error_msg}"
+            )
+        elif result.exit_kind == "killed":
+            logger.error(
+                f"Periodic task '{slot.name}' killed after {elapsed:.3f} s:"
+                f" {result.error_msg}"
+            )
+        else:
+            logger.error(
+                f"Periodic task '{slot.name}' failed after {elapsed:.3f} s:"
+                f" {result.error_msg}"
+            )
+
+        if slot.periodic_max_concurrent is not None:
+            try:
+                with pq.session() as session:
+                    session.execute(
+                        update(Periodic)
+                        .where(Periodic.id == slot.task_id)
+                        .values(locked_until=None)
+                    )
+            except Exception as e:
+                logger.error(
+                    f"Failed to clear lock for periodic task '{slot.name}': {e}"
+                )
+    else:
+        error_msg = result.error_msg
+        if result.exit_kind == "timeout":
+            error_msg = f"Timed out after {elapsed:.3f} s"
+
+        try:
+            with pq.session() as session:
+                task = session.get(Task, slot.task_id)
+                if task:
+                    task.status = result.task_status
+                    task.completed_at = datetime.now(UTC)
+                    if error_msg:
+                        task.error = error_msg
+        except Exception as e:
+            logger.error(f"Error updating task status: {e}")
+
+        if result.task_status == TaskStatus.COMPLETED:
+            logger.debug(f"Task '{slot.name}' completed in {elapsed:.3f} s")
+        else:
+            logger.error(
+                f"Task '{slot.name}' failed after {elapsed:.3f} s: {error_msg}"
+            )
+
+
+def _run_concurrent(
+    pq: PQ,
+    *,
+    concurrency: int,
+    poll_interval: float,
+    max_runtime: float,
+    priorities: Set[Priority] | None,
+    pre_execute: PreExecuteHook | None,
+    post_execute: PostExecuteHook | None,
+    retention_days: int,
+    cleanup_interval: float,
+) -> None:
+    """Run the concurrent worker loop.
+
+    Manages up to ``concurrency`` forked children simultaneously using
+    select() on error pipes to detect child completion.
+
+    Args:
+        pq: PQ client instance.
+        concurrency: Maximum number of concurrent tasks.
+        poll_interval: Seconds between polls when idle.
+        max_runtime: Maximum execution time per task in seconds.
+        priorities: If set, only process tasks with these priority levels.
+        pre_execute: Called in forked child BEFORE task execution.
+        post_execute: Called in forked child AFTER task execution.
+        retention_days: Days to keep completed/failed tasks.
+        cleanup_interval: Seconds between cleanup runs.
+    """
+    children: dict[int, _ChildSlot] = {}  # pid -> slot
+    fd_to_pid: dict[int, int] = {}  # read_fd -> pid
+    last_cleanup: list[float] = [0.0]
+
+    try:
+        while True:
+            # Step 1: Fill empty slots with new tasks
+            while len(children) < concurrency:
+                slot = _try_claim_and_fork(
+                    pq,
+                    max_runtime=max_runtime,
+                    priorities=priorities,
+                    pre_execute=pre_execute,
+                    post_execute=post_execute,
+                )
+                if slot is None:
+                    break
+                children[slot.pid] = slot
+                fd_to_pid[slot.read_fd] = slot.pid
+
+            # Step 2: Wait for events
+            if children:
+                read_fds = list(fd_to_pid.keys())
+                ready, _, _ = select_module.select(read_fds, [], [], poll_interval)
+                for fd in ready:
+                    pid = fd_to_pid.pop(fd)
+                    slot = children.pop(pid)
+                    _reap_and_update(pq, slot)
+            else:
+                time.sleep(poll_interval)
+
+            # Cleanup runs on every iteration (rate-limited internally)
+            _maybe_run_cleanup(pq, retention_days, cleanup_interval, last_cleanup)
+
+    except KeyboardInterrupt:
+        if children:
+            logger.info(
+                f"Shutting down, waiting for {len(children)} task(s) to finish..."
+            )
+            for slot in list(children.values()):
+                _reap_and_update(pq, slot)
+        logger.info("Worker stopped.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,14 @@ from pq.client import PQ
 @pytest.fixture
 def db_url() -> str:
     """Database URL for tests."""
-    return os.environ.get(
+    url = os.environ.get(
         "PQ_DATABASE_URL", "postgresql://postgres:postgres@localhost:5433/postgres"
     )
+    # Disable GSSAPI to prevent segfaults when forking (psycopg2-binary bundles
+    # libkrb5/libgssapi whose internal state corrupts across os.fork).
+    if "gssencmode" not in url:
+        url += "&gssencmode=disable" if "?" in url else "?gssencmode=disable"
+    return url
 
 
 @pytest.fixture

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -7,6 +7,7 @@ import asyncio
 import multiprocessing
 import multiprocessing.managers
 import time
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -753,153 +754,137 @@ class TestTaskTimeout:
 class TestConcurrentWorker:
     """Tests for concurrent worker mode (concurrency > 1)."""
 
-    def test_parallel_execution(
-        self, pq: PQ, manager: multiprocessing.managers.SyncManager
+    def _run_concurrent_worker(
+        self,
+        db_url: str,
+        *,
+        concurrency: int = 3,
+        max_runtime: float = 30,
+        poll_interval: float = 0.1,
+    ) -> tuple[int, int]:
+        """Fork a child running _run_concurrent. Returns (child_pid, parent_pid).
+
+        Creates a fresh PQ instance in the child to avoid sharing
+        the parent's connection pool across fork.
+
+        Caller must eventually os.kill(pid, SIGINT) and os.waitpid(pid, 0).
+        """
+        import os
+
+        from pq.worker import _run_concurrent
+
+        pid = os.fork()
+        if pid == 0:
+            child_pq = PQ(db_url)
+            try:
+                _run_concurrent(
+                    child_pq,
+                    concurrency=concurrency,
+                    poll_interval=poll_interval,
+                    max_runtime=max_runtime,
+                    priorities=None,
+                    pre_execute=None,
+                    post_execute=None,
+                    retention_days=0,
+                    cleanup_interval=3600,
+                )
+            except KeyboardInterrupt:
+                pass
+            child_pq.close()
+            os._exit(0)
+
+        return pid, os.getpid()
+
+    def _wait_for(
+        self,
+        predicate: Callable[[], bool],
+        *,
+        timeout: float = 5,
+        poll: float = 0.1,
     ) -> None:
-        """Multiple tasks execute in parallel, not sequentially."""
+        """Poll until predicate returns True, or raise AssertionError."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if predicate():
+                return
+            time.sleep(poll)
+        raise AssertionError(f"Condition not met within {timeout}s")
+
+    def _stop_worker(self, pid: int) -> None:
+        """Send SIGINT and wait for the worker to exit."""
+        import os
+        import signal as sig
+
+        os.kill(pid, sig.SIGINT)
+        os.waitpid(pid, 0)
+
+    def test_parallel_execution(
+        self, pq: PQ, db_url: str, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """5 tasks sleeping 1s complete in ~1s with concurrency=5, not 5s."""
         results = manager.list()
         _set_shared_results(results)
 
-        # Enqueue 5 tasks that each sleep 1 second
         for _ in range(5):
             pq.enqueue(sleep_handler, duration=1.0)
 
-        from pq.worker import _run_concurrent
-
         start = time.perf_counter()
+        pid, _ = self._run_concurrent_worker(db_url, concurrency=5)
 
-        import os
-        import signal as sig
-
-        pid = os.fork()
-        if pid == 0:
-            try:
-                _run_concurrent(
-                    pq,
-                    concurrency=5,
-                    poll_interval=0.1,
-                    max_runtime=30,
-                    priorities=None,
-                    pre_execute=None,
-                    post_execute=None,
-                    retention_days=0,
-                    cleanup_interval=3600,
-                )
-            except KeyboardInterrupt:
-                pass
-            os._exit(0)
-
-        # Parent: wait for tasks to complete, then stop worker
-        deadline = time.time() + 10
-        while time.time() < deadline:
-            time.sleep(0.2)
-            if len(results) >= 5:
-                break
-
-        os.kill(pid, sig.SIGINT)
-        os.waitpid(pid, 0)
+        self._wait_for(lambda: len(results) >= 5)
+        self._stop_worker(pid)
 
         elapsed = time.perf_counter() - start
+
         assert len(results) == 5
-        # Should complete in ~1-2s (parallel), not ~5s (sequential)
-        assert elapsed < 4.0
+        assert pq.pending_count() == 0
+        assert len(pq.list_completed()) == 5
+        assert elapsed < 2.5  # ~1s parallel + overhead, not 5s sequential
 
     def test_slot_refill(
-        self, pq: PQ, manager: multiprocessing.managers.SyncManager
+        self, pq: PQ, db_url: str, manager: multiprocessing.managers.SyncManager
     ) -> None:
-        """When a task finishes, the freed slot picks up the next task."""
+        """6 tasks with concurrency=3 run in 2 batches (~1s), not 6 sequential."""
         results = manager.list()
         _set_shared_results(results)
 
-        # Enqueue 6 tasks that each sleep 0.5 second
         for _ in range(6):
             pq.enqueue(sleep_handler, duration=0.5)
 
-        from pq.worker import _run_concurrent
-
-        import os
-        import signal as sig
-
         start = time.perf_counter()
+        pid, _ = self._run_concurrent_worker(db_url, concurrency=3)
 
-        pid = os.fork()
-        if pid == 0:
-            try:
-                _run_concurrent(
-                    pq,
-                    concurrency=3,
-                    poll_interval=0.1,
-                    max_runtime=30,
-                    priorities=None,
-                    pre_execute=None,
-                    post_execute=None,
-                    retention_days=0,
-                    cleanup_interval=3600,
-                )
-            except KeyboardInterrupt:
-                pass
-            os._exit(0)
-
-        deadline = time.time() + 10
-        while time.time() < deadline:
-            time.sleep(0.2)
-            if len(results) >= 6:
-                break
-
-        os.kill(pid, sig.SIGINT)
-        os.waitpid(pid, 0)
+        self._wait_for(lambda: len(results) >= 6)
+        self._stop_worker(pid)
 
         elapsed = time.perf_counter() - start
-        assert len(results) == 6
-        # 6 tasks, concurrency=3, 0.5s each → ~1s (2 batches), not 3s
-        assert elapsed < 3.0
 
-    def test_failed_task_concurrent(self, pq: PQ) -> None:
-        """Failed tasks are properly recorded in concurrent mode."""
+        assert len(results) == 6
+        assert pq.pending_count() == 0
+        assert len(pq.list_completed()) == 6
+        assert elapsed < 2.0  # 2 batches × 0.5s + overhead
+
+    def test_failed_task_concurrent(self, pq: PQ, db_url: str) -> None:
+        """Failed tasks have correct status, error type, and error message."""
         pq.enqueue(failing_handler)
 
-        from pq.worker import _run_concurrent
+        pid, _ = self._run_concurrent_worker(db_url)
 
-        import os
-        import signal as sig
-
-        pid = os.fork()
-        if pid == 0:
-            try:
-                _run_concurrent(
-                    pq,
-                    concurrency=3,
-                    poll_interval=0.1,
-                    max_runtime=30,
-                    priorities=None,
-                    pre_execute=None,
-                    post_execute=None,
-                    retention_days=0,
-                    cleanup_interval=3600,
-                )
-            except KeyboardInterrupt:
-                pass
-            os._exit(0)
-
-        # Wait for the task to be processed (poll instead of fixed sleep)
-        deadline = time.time() + 10
-        while time.time() < deadline:
-            time.sleep(0.2)
-            if pq.pending_count() == 0:
-                break
-
-        os.kill(pid, sig.SIGINT)
-        os.waitpid(pid, 0)
+        self._wait_for(lambda: pq.pending_count() == 0)
+        self._stop_worker(pid)
 
         assert pq.pending_count() == 0
         failed = pq.list_failed()
         assert len(failed) == 1
+        assert failed[0].status.value == "failed"
+        assert "ValueError" in (failed[0].error or "")
         assert "boom" in (failed[0].error or "")
+        assert failed[0].completed_at is not None
 
     def test_mixed_success_and_failure(
-        self, pq: PQ, manager: multiprocessing.managers.SyncManager
+        self, pq: PQ, db_url: str, manager: multiprocessing.managers.SyncManager
     ) -> None:
-        """Concurrent worker handles mix of successful and failing tasks."""
+        """Successful and failing tasks are tracked independently."""
         results = manager.list()
         _set_shared_results(results)
 
@@ -907,45 +892,18 @@ class TestConcurrentWorker:
         pq.enqueue(failing_handler)
         pq.enqueue(capture_handler, value=2)
 
-        from pq.worker import _run_concurrent
+        pid, _ = self._run_concurrent_worker(db_url, concurrency=3)
 
-        import os
-        import signal as sig
-
-        pid = os.fork()
-        if pid == 0:
-            try:
-                _run_concurrent(
-                    pq,
-                    concurrency=3,
-                    poll_interval=0.1,
-                    max_runtime=30,
-                    priorities=None,
-                    pre_execute=None,
-                    post_execute=None,
-                    retention_days=0,
-                    cleanup_interval=3600,
-                )
-            except KeyboardInterrupt:
-                pass
-            os._exit(0)
-
-        # Wait for all tasks to be processed (poll instead of fixed sleep)
-        deadline = time.time() + 10
-        while time.time() < deadline:
-            time.sleep(0.2)
-            if pq.pending_count() == 0 and len(results) >= 2:
-                break
-
-        os.kill(pid, sig.SIGINT)
-        os.waitpid(pid, 0)
+        self._wait_for(lambda: pq.pending_count() == 0 and len(results) >= 2)
+        self._stop_worker(pid)
 
         assert pq.pending_count() == 0
         assert sorted(results) == [1, 2]
+        assert len(pq.list_completed()) == 2
         assert len(pq.list_failed()) == 1
 
     def test_concurrent_periodic_task(
-        self, pq: PQ, manager: multiprocessing.managers.SyncManager
+        self, pq: PQ, db_url: str, manager: multiprocessing.managers.SyncManager
     ) -> None:
         """Periodic tasks are processed in concurrent mode."""
         results = manager.list()
@@ -953,37 +911,10 @@ class TestConcurrentWorker:
 
         pq.schedule(periodic_handler, 42, run_every=timedelta(hours=1))
 
-        from pq.worker import _run_concurrent
+        pid, _ = self._run_concurrent_worker(db_url)
 
-        import os
-        import signal as sig
-
-        pid = os.fork()
-        if pid == 0:
-            try:
-                _run_concurrent(
-                    pq,
-                    concurrency=3,
-                    poll_interval=0.1,
-                    max_runtime=30,
-                    priorities=None,
-                    pre_execute=None,
-                    post_execute=None,
-                    retention_days=0,
-                    cleanup_interval=3600,
-                )
-            except KeyboardInterrupt:
-                pass
-            os._exit(0)
-
-        deadline = time.time() + 10
-        while time.time() < deadline:
-            time.sleep(0.2)
-            if len(results) >= 1:
-                break
-
-        os.kill(pid, sig.SIGINT)
-        os.waitpid(pid, 0)
+        self._wait_for(lambda: len(results) >= 1)
+        self._stop_worker(pid)
 
         assert list(results) == [42]
 
@@ -1001,3 +932,4 @@ class TestConcurrentWorker:
         processed = run_worker_once(pq)
         assert processed is True
         assert list(results) == [42]
+        assert len(pq.list_completed()) == 1

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -98,6 +98,12 @@ def slow_sync_handler() -> None:
     time.sleep(10)
 
 
+def sleep_handler(duration: float) -> None:
+    """Sleep for a given duration. Used in concurrency tests."""
+    time.sleep(duration)
+    _shared_results.append(1)
+
+
 class TestRunWorkerOnce:
     """Tests for run_worker_once method."""
 
@@ -742,3 +748,256 @@ class TestTaskTimeout:
 
         # Task should be removed (marked failed)
         assert pq.pending_count() == 0
+
+
+class TestConcurrentWorker:
+    """Tests for concurrent worker mode (concurrency > 1)."""
+
+    def test_parallel_execution(
+        self, pq: PQ, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """Multiple tasks execute in parallel, not sequentially."""
+        results = manager.list()
+        _set_shared_results(results)
+
+        # Enqueue 5 tasks that each sleep 1 second
+        for _ in range(5):
+            pq.enqueue(sleep_handler, duration=1.0)
+
+        from pq.worker import _run_concurrent
+
+        start = time.perf_counter()
+
+        import os
+        import signal as sig
+
+        pid = os.fork()
+        if pid == 0:
+            try:
+                _run_concurrent(
+                    pq,
+                    concurrency=5,
+                    poll_interval=0.1,
+                    max_runtime=30,
+                    priorities=None,
+                    pre_execute=None,
+                    post_execute=None,
+                    retention_days=0,
+                    cleanup_interval=3600,
+                )
+            except KeyboardInterrupt:
+                pass
+            os._exit(0)
+
+        # Parent: wait for tasks to complete, then stop worker
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            time.sleep(0.2)
+            if len(results) >= 5:
+                break
+
+        os.kill(pid, sig.SIGINT)
+        os.waitpid(pid, 0)
+
+        elapsed = time.perf_counter() - start
+        assert len(results) == 5
+        # Should complete in ~1-2s (parallel), not ~5s (sequential)
+        assert elapsed < 4.0
+
+    def test_slot_refill(
+        self, pq: PQ, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """When a task finishes, the freed slot picks up the next task."""
+        results = manager.list()
+        _set_shared_results(results)
+
+        # Enqueue 6 tasks that each sleep 0.5 second
+        for _ in range(6):
+            pq.enqueue(sleep_handler, duration=0.5)
+
+        from pq.worker import _run_concurrent
+
+        import os
+        import signal as sig
+
+        start = time.perf_counter()
+
+        pid = os.fork()
+        if pid == 0:
+            try:
+                _run_concurrent(
+                    pq,
+                    concurrency=3,
+                    poll_interval=0.1,
+                    max_runtime=30,
+                    priorities=None,
+                    pre_execute=None,
+                    post_execute=None,
+                    retention_days=0,
+                    cleanup_interval=3600,
+                )
+            except KeyboardInterrupt:
+                pass
+            os._exit(0)
+
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            time.sleep(0.2)
+            if len(results) >= 6:
+                break
+
+        os.kill(pid, sig.SIGINT)
+        os.waitpid(pid, 0)
+
+        elapsed = time.perf_counter() - start
+        assert len(results) == 6
+        # 6 tasks, concurrency=3, 0.5s each → ~1s (2 batches), not 3s
+        assert elapsed < 3.0
+
+    def test_failed_task_concurrent(self, pq: PQ) -> None:
+        """Failed tasks are properly recorded in concurrent mode."""
+        pq.enqueue(failing_handler)
+
+        from pq.worker import _run_concurrent
+
+        import os
+        import signal as sig
+
+        pid = os.fork()
+        if pid == 0:
+            try:
+                _run_concurrent(
+                    pq,
+                    concurrency=3,
+                    poll_interval=0.1,
+                    max_runtime=30,
+                    priorities=None,
+                    pre_execute=None,
+                    post_execute=None,
+                    retention_days=0,
+                    cleanup_interval=3600,
+                )
+            except KeyboardInterrupt:
+                pass
+            os._exit(0)
+
+        # Wait for the task to be processed (poll instead of fixed sleep)
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            time.sleep(0.2)
+            if pq.pending_count() == 0:
+                break
+
+        os.kill(pid, sig.SIGINT)
+        os.waitpid(pid, 0)
+
+        assert pq.pending_count() == 0
+        failed = pq.list_failed()
+        assert len(failed) == 1
+        assert "boom" in (failed[0].error or "")
+
+    def test_mixed_success_and_failure(
+        self, pq: PQ, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """Concurrent worker handles mix of successful and failing tasks."""
+        results = manager.list()
+        _set_shared_results(results)
+
+        pq.enqueue(capture_handler, value=1)
+        pq.enqueue(failing_handler)
+        pq.enqueue(capture_handler, value=2)
+
+        from pq.worker import _run_concurrent
+
+        import os
+        import signal as sig
+
+        pid = os.fork()
+        if pid == 0:
+            try:
+                _run_concurrent(
+                    pq,
+                    concurrency=3,
+                    poll_interval=0.1,
+                    max_runtime=30,
+                    priorities=None,
+                    pre_execute=None,
+                    post_execute=None,
+                    retention_days=0,
+                    cleanup_interval=3600,
+                )
+            except KeyboardInterrupt:
+                pass
+            os._exit(0)
+
+        # Wait for all tasks to be processed (poll instead of fixed sleep)
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            time.sleep(0.2)
+            if pq.pending_count() == 0 and len(results) >= 2:
+                break
+
+        os.kill(pid, sig.SIGINT)
+        os.waitpid(pid, 0)
+
+        assert pq.pending_count() == 0
+        assert sorted(results) == [1, 2]
+        assert len(pq.list_failed()) == 1
+
+    def test_concurrent_periodic_task(
+        self, pq: PQ, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """Periodic tasks are processed in concurrent mode."""
+        results = manager.list()
+        _set_shared_results(results)
+
+        pq.schedule(periodic_handler, 42, run_every=timedelta(hours=1))
+
+        from pq.worker import _run_concurrent
+
+        import os
+        import signal as sig
+
+        pid = os.fork()
+        if pid == 0:
+            try:
+                _run_concurrent(
+                    pq,
+                    concurrency=3,
+                    poll_interval=0.1,
+                    max_runtime=30,
+                    priorities=None,
+                    pre_execute=None,
+                    post_execute=None,
+                    retention_days=0,
+                    cleanup_interval=3600,
+                )
+            except KeyboardInterrupt:
+                pass
+            os._exit(0)
+
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            time.sleep(0.2)
+            if len(results) >= 1:
+                break
+
+        os.kill(pid, sig.SIGINT)
+        os.waitpid(pid, 0)
+
+        assert list(results) == [42]
+
+    def test_concurrency_one_is_sequential(
+        self, pq: PQ, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """concurrency=1 preserves existing sequential behavior."""
+        results = manager.list()
+        _set_shared_results(results)
+
+        pq.enqueue(capture_handler, value=42)
+
+        from pq.worker import run_worker_once
+
+        processed = run_worker_once(pq)
+        assert processed is True
+        assert list(results) == [42]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -831,7 +831,9 @@ class TestConcurrentWorker:
         start = time.perf_counter()
         pid, _ = self._run_concurrent_worker(db_url, concurrency=5)
 
-        self._wait_for(lambda: len(results) >= 5)
+        # Wait for DB state (not just handler results) to avoid race between
+        # handler completion and worker reaping/updating the DB.
+        self._wait_for(lambda: len(pq.list_completed()) >= 5)
         self._stop_worker(pid)
 
         elapsed = time.perf_counter() - start
@@ -854,7 +856,7 @@ class TestConcurrentWorker:
         start = time.perf_counter()
         pid, _ = self._run_concurrent_worker(db_url, concurrency=3)
 
-        self._wait_for(lambda: len(results) >= 6)
+        self._wait_for(lambda: len(pq.list_completed()) >= 6)
         self._stop_worker(pid)
 
         elapsed = time.perf_counter() - start
@@ -870,7 +872,7 @@ class TestConcurrentWorker:
 
         pid, _ = self._run_concurrent_worker(db_url)
 
-        self._wait_for(lambda: pq.pending_count() == 0)
+        self._wait_for(lambda: len(pq.list_failed()) >= 1)
         self._stop_worker(pid)
 
         assert pq.pending_count() == 0
@@ -894,7 +896,9 @@ class TestConcurrentWorker:
 
         pid, _ = self._run_concurrent_worker(db_url, concurrency=3)
 
-        self._wait_for(lambda: pq.pending_count() == 0 and len(results) >= 2)
+        self._wait_for(
+            lambda: len(pq.list_completed()) >= 2 and len(pq.list_failed()) >= 1
+        )
         self._stop_worker(pid)
 
         assert pq.pending_count() == 0
@@ -917,6 +921,183 @@ class TestConcurrentWorker:
         self._stop_worker(pid)
 
         assert list(results) == [42]
+
+    def test_graceful_shutdown_completes_in_flight(
+        self, pq: PQ, db_url: str, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """SIGINT during execution waits for in-flight tasks to complete."""
+        results = manager.list()
+        _set_shared_results(results)
+
+        for _ in range(3):
+            pq.enqueue(sleep_handler, duration=1.5)
+
+        pid, _ = self._run_concurrent_worker(db_url, concurrency=3)
+
+        # Wait for tasks to start but not finish
+        time.sleep(0.5)
+
+        # SIGINT — worker should wait for in-flight tasks before exiting
+        self._stop_worker(pid)
+
+        # All 3 should have completed (worker waited for them)
+        assert len(results) == 3
+        assert pq.pending_count() == 0
+        assert len(pq.list_completed()) == 3
+
+    def test_timeout_concurrent(self, pq: PQ, db_url: str) -> None:
+        """Task exceeding max_runtime is killed and marked failed."""
+        pq.enqueue(slow_sync_handler)  # sleeps 10s
+
+        pid, _ = self._run_concurrent_worker(db_url, max_runtime=1)
+
+        self._wait_for(lambda: len(pq.list_failed()) >= 1, timeout=10)
+        self._stop_worker(pid)
+
+        failed = pq.list_failed()
+        assert len(failed) == 1
+        assert "Timed out" in (failed[0].error or "")
+        assert failed[0].completed_at is not None
+
+    def test_priority_ordering_concurrent(
+        self, pq: PQ, db_url: str, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """Higher priority tasks are claimed first in concurrent mode."""
+        results = manager.list()
+        _set_shared_results(results)
+
+        # Enqueue in reverse priority order
+        pq.enqueue(ordered_handler, n=3, priority=Priority.LOW)
+        pq.enqueue(ordered_handler, n=1, priority=Priority.HIGH)
+        pq.enqueue(ordered_handler, n=2, priority=Priority.NORMAL)
+
+        # concurrency=1 forces sequential claiming within the concurrent loop
+        pid, _ = self._run_concurrent_worker(db_url, concurrency=1)
+
+        self._wait_for(lambda: len(pq.list_completed()) >= 3)
+        self._stop_worker(pid)
+
+        assert list(results) == [1, 2, 3]
+
+    def test_mixed_one_off_and_periodic_concurrent(
+        self, pq: PQ, db_url: str, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """One-off and periodic tasks are processed together."""
+        results = manager.list()
+        _set_shared_results(results)
+
+        pq.enqueue(capture_handler, value="one-off")
+        pq.schedule(periodic_handler, 42, run_every=timedelta(hours=1))
+
+        pid, _ = self._run_concurrent_worker(db_url, concurrency=3)
+
+        self._wait_for(lambda: len(results) >= 2)
+        self._stop_worker(pid)
+
+        assert "one-off" in list(results)
+        assert 42 in list(results)
+        assert len(pq.list_completed()) == 1  # one-off tracked in tasks table
+
+    def test_failed_periodic_concurrent(self, pq: PQ, db_url: str) -> None:
+        """Failed periodic tasks clear lock and advance schedule in concurrent mode."""
+        from sqlalchemy import select as sa_select
+
+        pq.schedule(failing_handler, run_every=timedelta(hours=1))
+
+        pid, _ = self._run_concurrent_worker(db_url)
+
+        # Wait for the periodic task to be processed (schedule advances)
+        self._wait_for(
+            lambda: self._periodic_was_run(pq, "tests.test_worker:failing_handler")
+        )
+        self._stop_worker(pid)
+
+        # Verify lock is cleared and schedule is advanced
+        with pq.session() as session:
+            periodic = session.execute(
+                sa_select(Periodic).where(
+                    Periodic.name == "tests.test_worker:failing_handler"
+                )
+            ).scalar_one()
+            assert periodic.locked_until is None  # lock cleared
+            assert periodic.last_run is not None  # was run
+
+    def test_priority_filter_concurrent(
+        self, pq: PQ, db_url: str, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """Priority filter restricts which tasks are claimed in concurrent mode."""
+        results = manager.list()
+        _set_shared_results(results)
+
+        pq.enqueue(ordered_handler, n=1, priority=Priority.HIGH)
+        pq.enqueue(ordered_handler, n=2, priority=Priority.NORMAL)
+        pq.enqueue(ordered_handler, n=3, priority=Priority.LOW)
+
+        from pq.worker import _run_concurrent
+
+        import os
+        import signal as sig
+
+        pid = os.fork()
+        if pid == 0:
+            child_pq = PQ(db_url)
+            try:
+                _run_concurrent(
+                    child_pq,
+                    concurrency=3,
+                    poll_interval=0.1,
+                    max_runtime=30,
+                    priorities={Priority.HIGH},
+                    pre_execute=None,
+                    post_execute=None,
+                    retention_days=0,
+                    cleanup_interval=3600,
+                )
+            except KeyboardInterrupt:
+                pass
+            child_pq.close()
+            os._exit(0)
+
+        self._wait_for(lambda: len(pq.list_completed()) >= 1)
+        # Give it time to potentially pick up more tasks (it shouldn't)
+        time.sleep(0.3)
+        os.kill(pid, sig.SIGINT)
+        os.waitpid(pid, 0)
+
+        assert list(results) == [1]  # only HIGH
+        assert len(pq.list_completed()) == 1
+        assert pq.pending_count() == 2  # NORMAL and LOW still pending
+
+    def _periodic_was_run(self, pq: PQ, name: str) -> bool:
+        """Check if a periodic task's last_run was set."""
+        from sqlalchemy import select as sa_select
+
+        with pq.session() as session:
+            periodic = session.execute(
+                sa_select(Periodic).where(Periodic.name == name)
+            ).scalar_one_or_none()
+            return periodic is not None and periodic.last_run is not None
+
+    def test_future_task_not_claimed_concurrent(self, pq: PQ, db_url: str) -> None:
+        """Tasks with run_at in the future are not picked up."""
+        future = datetime.now(UTC) + timedelta(hours=1)
+        pq.enqueue(noop_handler, run_at=future)
+
+        pid, _ = self._run_concurrent_worker(db_url)
+
+        time.sleep(0.5)
+        self._stop_worker(pid)
+
+        assert pq.pending_count() == 1  # still waiting
+
+    def test_empty_queue_concurrent(self, pq: PQ, db_url: str) -> None:
+        """Worker idles on empty queue without errors."""
+        pid, _ = self._run_concurrent_worker(db_url)
+
+        time.sleep(0.5)
+        self._stop_worker(pid)
+
+        assert pq.pending_count() == 0
 
     def test_concurrency_one_is_sequential(
         self, pq: PQ, manager: multiprocessing.managers.SyncManager

--- a/uv.lock
+++ b/uv.lock
@@ -722,7 +722,7 @@ wheels = [
 
 [[package]]
 name = "python-pq"
-version = "0.5.2"
+version = "0.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- Add `concurrency` parameter to `run_worker()` and `PQ.run_worker()` allowing a single worker to process up to N tasks in parallel
- Uses a single-threaded parent managing N forked children via `select()` on error pipes (Gunicorn-style architecture — no fork+threads POSIX issues)
- `concurrency=1` (default) preserves exact existing sequential behavior
- Refactors `_execute_in_fork` into composable `_fork_child` + `_wait_for_child` building blocks

### How it works

1. Fill empty slots by claiming tasks (`FOR UPDATE SKIP LOCKED LIMIT 1`) and forking children
2. `select()` on error pipe read FDs waits for any child to finish (event-driven, no polling)
3. When a pipe becomes readable (child exited), reap with `os.wait4` and update task status
4. Loop back to fill freed slots
5. On `KeyboardInterrupt`, wait for all in-flight children to complete

## Test plan

- [x] `test_parallel_execution` — 5 tasks sleeping 1s complete in <4s with `concurrency=5`
- [x] `test_slot_refill` — 6 tasks with `concurrency=3` complete in <3s (2 batches)
- [x] `test_failed_task_concurrent` — failed task properly recorded in DB
- [x] `test_mixed_success_and_failure` — mix of success/failure handled correctly
- [x] `test_concurrent_periodic_task` — periodic tasks work in concurrent mode
- [x] `test_concurrency_one_is_sequential` — default behavior unchanged
- [x] All 117 tests pass (111 existing + 6 new)
- [x] ruff check, ruff format, ty check all pass