### PR TITLE
feat: per-task max_runtime override on enqueue / upsert / schedule

### DIFF
--- a/src/pq/client.py
+++ b/src/pq/client.py
@@ -1,6 +1,7 @@
 """PQ client - main interface for task queue."""
 
 import importlib.resources
+import math
 from collections.abc import Callable, Set
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
@@ -26,15 +27,18 @@ def _validate_max_runtime(max_runtime: float | None) -> None:
     """Reject obviously-degenerate per-task ``max_runtime`` values.
 
     ``None`` means "use the worker's configured default" and is the
-    common case — nothing to validate. ``0`` or negative is rejected
-    because the downstream enforcement is undefined for those:
+    common case — nothing to validate. ``0``, negative, NaN, and
+    infinity are all rejected because the downstream enforcement is
+    undefined for those:
 
     - ``signal.alarm(int(max_runtime) + 1)`` would fire at 1 s for
-      ``0`` and at 0 s (which disables the alarm entirely) for any
-      negative integer ≥ -1.
-    - ``max_runtime * 2`` in the stale-reaper SQL would be ≤ 0,
-      making the per-row threshold a no-op (the global default would
-      apply) — silent surprise vs. the call site's intent.
+      ``0``, at 0 s (which disables the alarm entirely) for any
+      negative integer ≥ -1, and raise ``ValueError`` from inside
+      the worker for NaN / infinity.
+    - ``max_runtime * 2`` in the stale-reaper SQL would be ≤ 0 or
+      NaN, making the per-row threshold a no-op or NULL (the global
+      default would apply) — silent surprise vs. the call site's
+      intent.
     - Periodic ``lock_duration`` already guards with a 3600 s
       fallback for ``≤ 0`` (``worker.py``), but that fallback exists
       for the worker-level default, not as a contract for callers.
@@ -46,6 +50,11 @@ def _validate_max_runtime(max_runtime: float | None) -> None:
     """
     if max_runtime is None:
         return
+    if math.isnan(max_runtime) or math.isinf(max_runtime):
+        raise ValueError(
+            f"max_runtime must be a finite positive number (got {max_runtime!r}); "
+            f"pass None to use the worker's configured default."
+        )
     if max_runtime <= 0:
         raise ValueError(
             f"max_runtime must be > 0 (got {max_runtime!r}); pass None to "

--- a/src/pq/client.py
+++ b/src/pq/client.py
@@ -22,6 +22,37 @@ from pq.registry import get_function_path
 from pq.serialization import serialize
 
 
+def _validate_max_runtime(max_runtime: float | None) -> None:
+    """Reject obviously-degenerate per-task ``max_runtime`` values.
+
+    ``None`` means "use the worker's configured default" and is the
+    common case — nothing to validate. ``0`` or negative is rejected
+    because the downstream enforcement is undefined for those:
+
+    - ``signal.alarm(int(max_runtime) + 1)`` would fire at 1 s for
+      ``0`` and at 0 s (which disables the alarm entirely) for any
+      negative integer ≥ -1.
+    - ``max_runtime * 2`` in the stale-reaper SQL would be ≤ 0,
+      making the per-row threshold a no-op (the global default would
+      apply) — silent surprise vs. the call site's intent.
+    - Periodic ``lock_duration`` already guards with a 3600 s
+      fallback for ``≤ 0`` (``worker.py``), but that fallback exists
+      for the worker-level default, not as a contract for callers.
+
+    None of these are useful behaviours to expose. Failing fast at
+    enqueue/upsert/schedule time keeps the bug at the call site,
+    where it's trivially fixable, instead of producing a confusing
+    runtime surprise hours later.
+    """
+    if max_runtime is None:
+        return
+    if max_runtime <= 0:
+        raise ValueError(
+            f"max_runtime must be > 0 (got {max_runtime!r}); pass None to "
+            f"use the worker's configured default."
+        )
+
+
 class PQ:
     """Postgres-backed task queue client."""
 
@@ -150,9 +181,11 @@ class PQ:
             Task ID.
 
         Raises:
-            ValueError: If task is a lambda, closure, or cannot be imported.
+            ValueError: If task is a lambda, closure, or cannot be imported,
+                or if ``max_runtime`` is not None and ``<= 0``.
             IntegrityError: If client_id already exists.
         """
+        _validate_max_runtime(max_runtime)
         name = get_function_path(task)
         payload = serialize(args, kwargs)
 
@@ -203,8 +236,10 @@ class PQ:
             Task ID.
 
         Raises:
-            ValueError: If task is a lambda, closure, or cannot be imported.
+            ValueError: If task is a lambda, closure, or cannot be imported,
+                or if ``max_runtime`` is not None and ``<= 0``.
         """
+        _validate_max_runtime(max_runtime)
         name = get_function_path(task)
         payload = serialize(args, kwargs)
 
@@ -295,6 +330,7 @@ class PQ:
             ValueError: If cron expression is invalid.
             ValueError: If max_concurrent is greater than 1.
             ValueError: If task is a lambda, closure, or cannot be imported.
+            ValueError: If ``max_runtime`` is not None and ``<= 0``.
             IntegrityError: If client_id already exists.
         """
         if run_every is None and cron is None:
@@ -306,6 +342,7 @@ class PQ:
                 f"max_concurrent must be 1 or None, got {max_concurrent} "
                 "(values > 1 reserved for future use)"
             )
+        _validate_max_runtime(max_runtime)
 
         # Validate and normalize cron expression
         cron_expr: str | None = None
@@ -581,6 +618,22 @@ class PQ:
             sa.literal(0),  # mins
             effective_threshold_seconds,  # secs
         )
+        # Per-row ``error`` message includes the values that actually
+        # decided this row's fate: the row's own
+        # ``max_runtime_seconds`` (or ``NULL`` if unset) and the
+        # effective threshold the reaper applied. This avoids the
+        # operator needing a separate query to figure out "why did MY
+        # long-budget task get reaped?" — the answer is in the row.
+        # Built with Postgres ``format()`` so the message is computed
+        # per row in the same UPDATE round-trip.
+        per_row_error = sa.func.format(
+            "Reaped: task still RUNNING past its stale window "
+            "(default threshold=%s s, per-task max_runtime_seconds=%s, "
+            "effective threshold=%s s). Worker likely died.",
+            threshold_seconds,
+            sa.func.coalesce(sa.cast(Task.max_runtime_seconds, sa.String), "NULL"),
+            effective_threshold_seconds,
+        )
         with self.session() as session:
             stmt = (
                 update(Task)
@@ -591,20 +644,21 @@ class PQ:
                 .values(
                     status=TaskStatus.FAILED,
                     completed_at=now,
-                    error=(
-                        f"Reaped: task still RUNNING past its stale window "
-                        f"(default threshold={threshold}; per-task override "
-                        f"max_runtime_seconds is honored when present). "
-                        f"Worker likely died."
-                    ),
+                    error=per_row_error,
                 )
-                .returning(Task.id, Task.name, Task.started_at)
+                .returning(
+                    Task.id,
+                    Task.name,
+                    Task.started_at,
+                    Task.max_runtime_seconds,
+                )
             )
             reaped = list(session.execute(stmt).all())
-            for task_id, name, started_at in reaped:
+            for task_id, name, started_at, max_runtime_seconds in reaped:
                 logger.warning(
                     f"Reaped stale task '{name}' (id={task_id},"
-                    f" started_at={started_at})"
+                    f" started_at={started_at},"
+                    f" max_runtime_seconds={max_runtime_seconds})"
                 )
             return len(reaped)
 

--- a/src/pq/client.py
+++ b/src/pq/client.py
@@ -10,6 +10,7 @@ from typing import Any, Self
 from croniter import croniter
 from croniter.croniter import CroniterBadCronError
 from loguru import logger
+import sqlalchemy as sa
 from sqlalchemy import create_engine, delete, func, select, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.engine import Engine
@@ -125,6 +126,7 @@ class PQ:
         run_at: datetime | None = None,
         priority: Priority = Priority.NORMAL,
         client_id: str | None = None,
+        max_runtime: float | None = None,
         **kwargs: Any,
     ) -> int:
         """Enqueue a one-off task.
@@ -135,6 +137,13 @@ class PQ:
             run_at: When to run the task. Defaults to now.
             priority: Task priority. Higher = higher priority. Defaults to NORMAL.
             client_id: Optional client-provided identifier. Must be unique if provided.
+            max_runtime: Per-task wall-clock cap in seconds. When ``None`` (the
+                common case), the worker that picks up this task uses its
+                configured default. When set, this specific task gets the
+                supplied ceiling AND the stale-reaper threshold scales with
+                it (``max_runtime * 2`` if larger than the reaper's global
+                default). Use this for occasionally-long tasks in a fleet
+                whose worker default is sized for typical short work.
             **kwargs: Keyword arguments to pass to the handler.
 
         Returns:
@@ -156,6 +165,7 @@ class PQ:
             run_at=run_at,
             priority=priority,
             client_id=client_id,
+            max_runtime_seconds=max_runtime,
         )
 
         with self.session() as session:
@@ -170,6 +180,7 @@ class PQ:
         run_at: datetime | None = None,
         priority: Priority = Priority.NORMAL,
         client_id: str,
+        max_runtime: float | None = None,
         **kwargs: Any,
     ) -> int:
         """Enqueue a task, updating if client_id already exists.
@@ -183,6 +194,9 @@ class PQ:
             run_at: When to run the task. Defaults to now.
             priority: Task priority. Higher = higher priority. Defaults to NORMAL.
             client_id: Client-provided identifier. Required for conflict resolution.
+            max_runtime: Per-task wall-clock cap in seconds. See ``enqueue`` for
+                details. ``None`` (the default) leaves the worker's own
+                configured ``max_runtime`` in effect.
             **kwargs: Keyword arguments to pass to the handler.
 
         Returns:
@@ -206,6 +220,7 @@ class PQ:
                 priority=priority,
                 status=TaskStatus.PENDING,
                 run_at=run_at,
+                max_runtime_seconds=max_runtime,
             )
             .on_conflict_do_update(
                 index_elements=["client_id"],
@@ -215,6 +230,7 @@ class PQ:
                     "priority": priority,
                     "status": TaskStatus.PENDING,
                     "run_at": run_at,
+                    "max_runtime_seconds": max_runtime,
                     "attempts": 0,
                     "started_at": None,
                     "completed_at": None,
@@ -239,6 +255,7 @@ class PQ:
         max_concurrent: int | None = 1,
         key: str = "",
         active: bool = True,
+        max_runtime: float | None = None,
         **kwargs: Any,
     ) -> int:
         """Schedule a periodic task.
@@ -260,6 +277,14 @@ class PQ:
                 Defaults to "" (empty string).
             active: Whether the task is active. Inactive tasks are not executed.
                 Defaults to True.
+            max_runtime: Per-execution wall-clock cap in seconds. When ``None``
+                (the common case), each execution uses the worker's configured
+                default. When set, this schedule's executions get the
+                supplied ceiling, and the ``locked_until`` window (used when
+                ``max_concurrent`` is in effect) is extended to match so the
+                lock doesn't expire while the execution is legitimately still
+                running. Periodic tasks are not subject to the stale-task
+                reaper, so this knob is purely about the wall-clock cap.
             **kwargs: Keyword arguments to pass to the handler.
 
         Returns:
@@ -321,6 +346,7 @@ class PQ:
                     client_id=client_id,
                     max_concurrent=max_concurrent,
                     active=active,
+                    max_runtime_seconds=max_runtime,
                 )
                 .on_conflict_do_update(
                     index_elements=["name", "key"],
@@ -332,6 +358,7 @@ class PQ:
                         "next_run": next_run,
                         "max_concurrent": max_concurrent,
                         "active": active,
+                        "max_runtime_seconds": max_runtime,
                     },
                 )
                 .returning(Periodic.id)
@@ -516,30 +543,59 @@ class PQ:
         process remains to update their status. This method detects those
         orphaned rows and transitions them to FAILED.
 
+        Tasks enqueued with a per-task ``max_runtime`` override get a
+        proportionally larger reaper window: the effective threshold for
+        a row is ``max(threshold, max_runtime_seconds * 2)``. This avoids
+        reaping a legitimately long-running task whose declared budget
+        exceeds the global default. NULL ``max_runtime_seconds`` (the
+        common case) falls back to the supplied ``threshold`` unchanged.
+
         Args:
-            threshold: A task is considered stale when
-                ``started_at + threshold < now()``. Should be at least
-                2x ``max_runtime`` to avoid reaping legitimately running
-                tasks, e.g. ``timedelta(seconds=max_runtime * 2)``.
+            threshold: Default per-task stale window for tasks that don't
+                have a ``max_runtime_seconds`` override (or whose override
+                is smaller than this default). A task is stale when
+                ``started_at + effective_threshold < now()``. Should be
+                at least 2x the worker's own ``max_runtime``, e.g.
+                ``timedelta(seconds=max_runtime * 2)``.
 
         Returns:
             Number of tasks reaped.
         """
         now = datetime.now(UTC)
-        cutoff = now - threshold
+        threshold_seconds = threshold.total_seconds()
+        # Per-row effective stale window: the larger of the supplied
+        # default and 2x the row's per-task override (NULL → just the
+        # default). Computed in SQL with ``GREATEST`` + ``COALESCE``
+        # so the reaper stays a single round-trip even when the row
+        # set is heterogeneous in declared budget.
+        effective_threshold_seconds = sa.func.greatest(
+            threshold_seconds,
+            sa.func.coalesce(Task.max_runtime_seconds * 2, threshold_seconds),
+        )
+        stale_cutoff = sa.func.now() - sa.func.make_interval(
+            sa.literal(0),  # years
+            sa.literal(0),  # months
+            sa.literal(0),  # weeks
+            sa.literal(0),  # days
+            sa.literal(0),  # hours
+            sa.literal(0),  # mins
+            effective_threshold_seconds,  # secs
+        )
         with self.session() as session:
             stmt = (
                 update(Task)
                 .where(
                     Task.status == TaskStatus.RUNNING,
-                    Task.started_at < cutoff,
+                    Task.started_at < stale_cutoff,
                 )
                 .values(
                     status=TaskStatus.FAILED,
                     completed_at=now,
                     error=(
-                        f"Reaped: task still RUNNING after {threshold} "
-                        f"(cutoff={cutoff.isoformat()}). Worker likely died."
+                        f"Reaped: task still RUNNING past its stale window "
+                        f"(default threshold={threshold}; per-task override "
+                        f"max_runtime_seconds is honored when present). "
+                        f"Worker likely died."
                     ),
                 )
                 .returning(Task.id, Task.name, Task.started_at)

--- a/src/pq/client.py
+++ b/src/pq/client.py
@@ -23,19 +23,19 @@ from pq.registry import get_function_path
 from pq.serialization import serialize
 
 
-def _validate_max_runtime(max_runtime: float | None) -> None:
-    """Reject obviously-degenerate per-task ``max_runtime`` values.
+def _validate_max_runtime(max_runtime_seconds: float | None) -> None:
+    """Reject obviously-degenerate per-task ``max_runtime_seconds`` values.
 
     ``None`` means "use the worker's configured default" and is the
     common case — nothing to validate. ``0``, negative, NaN, and
     infinity are all rejected because the downstream enforcement is
     undefined for those:
 
-    - ``signal.alarm(int(max_runtime) + 1)`` would fire at 1 s for
+    - ``signal.alarm(int(max_runtime_seconds) + 1)`` would fire at 1 s for
       ``0``, at 0 s (which disables the alarm entirely) for any
       negative integer ≥ -1, and raise ``ValueError`` from inside
       the worker for NaN / infinity.
-    - ``max_runtime * 2`` in the stale-reaper SQL would be ≤ 0 or
+    - ``max_runtime_seconds * 2`` in the stale-reaper SQL would be ≤ 0 or
       NaN, making the per-row threshold a no-op or NULL (the global
       default would apply) — silent surprise vs. the call site's
       intent.
@@ -48,16 +48,16 @@ def _validate_max_runtime(max_runtime: float | None) -> None:
     where it's trivially fixable, instead of producing a confusing
     runtime surprise hours later.
     """
-    if max_runtime is None:
+    if max_runtime_seconds is None:
         return
-    if math.isnan(max_runtime) or math.isinf(max_runtime):
+    if math.isnan(max_runtime_seconds) or math.isinf(max_runtime_seconds):
         raise ValueError(
-            f"max_runtime must be a finite positive number (got {max_runtime!r}); "
+            f"max_runtime_seconds must be a finite positive number (got {max_runtime_seconds!r}); "
             f"pass None to use the worker's configured default."
         )
-    if max_runtime <= 0:
+    if max_runtime_seconds <= 0:
         raise ValueError(
-            f"max_runtime must be > 0 (got {max_runtime!r}); pass None to "
+            f"max_runtime_seconds must be > 0 (got {max_runtime_seconds!r}); pass None to "
             f"use the worker's configured default."
         )
 
@@ -166,7 +166,7 @@ class PQ:
         run_at: datetime | None = None,
         priority: Priority = Priority.NORMAL,
         client_id: str | None = None,
-        max_runtime: float | None = None,
+        max_runtime_seconds: float | None = None,
         **kwargs: Any,
     ) -> int:
         """Enqueue a one-off task.
@@ -177,11 +177,11 @@ class PQ:
             run_at: When to run the task. Defaults to now.
             priority: Task priority. Higher = higher priority. Defaults to NORMAL.
             client_id: Optional client-provided identifier. Must be unique if provided.
-            max_runtime: Per-task wall-clock cap in seconds. When ``None`` (the
+            max_runtime_seconds: Per-task wall-clock cap in seconds. When ``None`` (the
                 common case), the worker that picks up this task uses its
                 configured default. When set, this specific task gets the
                 supplied ceiling AND the stale-reaper threshold scales with
-                it (``max_runtime * 2`` if larger than the reaper's global
+                it (``max_runtime_seconds * 2`` if larger than the reaper's global
                 default). Use this for occasionally-long tasks in a fleet
                 whose worker default is sized for typical short work.
             **kwargs: Keyword arguments to pass to the handler.
@@ -191,10 +191,10 @@ class PQ:
 
         Raises:
             ValueError: If task is a lambda, closure, or cannot be imported,
-                or if ``max_runtime`` is not None and ``<= 0``.
+                or if ``max_runtime_seconds`` is not None and ``<= 0``.
             IntegrityError: If client_id already exists.
         """
-        _validate_max_runtime(max_runtime)
+        _validate_max_runtime(max_runtime_seconds)
         name = get_function_path(task)
         payload = serialize(args, kwargs)
 
@@ -207,7 +207,7 @@ class PQ:
             run_at=run_at,
             priority=priority,
             client_id=client_id,
-            max_runtime_seconds=max_runtime,
+            max_runtime_seconds=max_runtime_seconds,
         )
 
         with self.session() as session:
@@ -222,7 +222,7 @@ class PQ:
         run_at: datetime | None = None,
         priority: Priority = Priority.NORMAL,
         client_id: str,
-        max_runtime: float | None = None,
+        max_runtime_seconds: float | None = None,
         **kwargs: Any,
     ) -> int:
         """Enqueue a task, updating if client_id already exists.
@@ -236,9 +236,9 @@ class PQ:
             run_at: When to run the task. Defaults to now.
             priority: Task priority. Higher = higher priority. Defaults to NORMAL.
             client_id: Client-provided identifier. Required for conflict resolution.
-            max_runtime: Per-task wall-clock cap in seconds. See ``enqueue`` for
+            max_runtime_seconds: Per-task wall-clock cap in seconds. See ``enqueue`` for
                 details. ``None`` (the default) leaves the worker's own
-                configured ``max_runtime`` in effect.
+                configured ``max_runtime_seconds`` in effect.
             **kwargs: Keyword arguments to pass to the handler.
 
         Returns:
@@ -246,9 +246,9 @@ class PQ:
 
         Raises:
             ValueError: If task is a lambda, closure, or cannot be imported,
-                or if ``max_runtime`` is not None and ``<= 0``.
+                or if ``max_runtime_seconds`` is not None and ``<= 0``.
         """
-        _validate_max_runtime(max_runtime)
+        _validate_max_runtime(max_runtime_seconds)
         name = get_function_path(task)
         payload = serialize(args, kwargs)
 
@@ -264,7 +264,7 @@ class PQ:
                 priority=priority,
                 status=TaskStatus.PENDING,
                 run_at=run_at,
-                max_runtime_seconds=max_runtime,
+                max_runtime_seconds=max_runtime_seconds,
             )
             .on_conflict_do_update(
                 index_elements=["client_id"],
@@ -274,7 +274,7 @@ class PQ:
                     "priority": priority,
                     "status": TaskStatus.PENDING,
                     "run_at": run_at,
-                    "max_runtime_seconds": max_runtime,
+                    "max_runtime_seconds": max_runtime_seconds,
                     "attempts": 0,
                     "started_at": None,
                     "completed_at": None,
@@ -299,7 +299,7 @@ class PQ:
         max_concurrent: int | None = 1,
         key: str = "",
         active: bool = True,
-        max_runtime: float | None = None,
+        max_runtime_seconds: float | None = None,
         **kwargs: Any,
     ) -> int:
         """Schedule a periodic task.
@@ -321,7 +321,7 @@ class PQ:
                 Defaults to "" (empty string).
             active: Whether the task is active. Inactive tasks are not executed.
                 Defaults to True.
-            max_runtime: Per-execution wall-clock cap in seconds. When ``None``
+            max_runtime_seconds: Per-execution wall-clock cap in seconds. When ``None``
                 (the common case), each execution uses the worker's configured
                 default. When set, this schedule's executions get the
                 supplied ceiling, and the ``locked_until`` window (used when
@@ -339,7 +339,7 @@ class PQ:
             ValueError: If cron expression is invalid.
             ValueError: If max_concurrent is greater than 1.
             ValueError: If task is a lambda, closure, or cannot be imported.
-            ValueError: If ``max_runtime`` is not None and ``<= 0``.
+            ValueError: If ``max_runtime_seconds`` is not None and ``<= 0``.
             IntegrityError: If client_id already exists.
         """
         if run_every is None and cron is None:
@@ -351,7 +351,7 @@ class PQ:
                 f"max_concurrent must be 1 or None, got {max_concurrent} "
                 "(values > 1 reserved for future use)"
             )
-        _validate_max_runtime(max_runtime)
+        _validate_max_runtime(max_runtime_seconds)
 
         # Validate and normalize cron expression
         cron_expr: str | None = None
@@ -392,7 +392,7 @@ class PQ:
                     client_id=client_id,
                     max_concurrent=max_concurrent,
                     active=active,
-                    max_runtime_seconds=max_runtime,
+                    max_runtime_seconds=max_runtime_seconds,
                 )
                 .on_conflict_do_update(
                     index_elements=["name", "key"],
@@ -404,7 +404,7 @@ class PQ:
                         "next_run": next_run,
                         "max_concurrent": max_concurrent,
                         "active": active,
-                        "max_runtime_seconds": max_runtime,
+                        "max_runtime_seconds": max_runtime_seconds,
                     },
                 )
                 .returning(Periodic.id)
@@ -589,7 +589,7 @@ class PQ:
         process remains to update their status. This method detects those
         orphaned rows and transitions them to FAILED.
 
-        Tasks enqueued with a per-task ``max_runtime`` override get a
+        Tasks enqueued with a per-task ``max_runtime_seconds`` override get a
         proportionally larger reaper window: the effective threshold for
         a row is ``max(threshold, max_runtime_seconds * 2)``. This avoids
         reaping a legitimately long-running task whose declared budget
@@ -601,8 +601,8 @@ class PQ:
                 have a ``max_runtime_seconds`` override (or whose override
                 is smaller than this default). A task is stale when
                 ``started_at + effective_threshold < now()``. Should be
-                at least 2x the worker's own ``max_runtime``, e.g.
-                ``timedelta(seconds=max_runtime * 2)``.
+                at least 2x the worker's own ``max_runtime_seconds``, e.g.
+                ``timedelta(seconds=max_runtime_seconds * 2)``.
 
         Returns:
             Number of tasks reaped.

--- a/src/pq/migrations/versions/20260527T170136Z_aee3e8e7e647_add_task_max_runtime_seconds.py
+++ b/src/pq/migrations/versions/20260527T170136Z_aee3e8e7e647_add_task_max_runtime_seconds.py
@@ -1,0 +1,50 @@
+"""add max_runtime_seconds to pq_tasks and pq_periodic
+
+Revision ID: aee3e8e7e647
+Revises: c3d4e5f6a7b8
+Create Date: 2026-05-27 17:01:36 Z
+
+Per-task override for the worker's wall-clock ``max_runtime`` cap, on
+both one-off tasks (``pq_tasks``) and periodic schedules
+(``pq_periodic``). Nullable on both so every existing row (and every
+existing enqueue / schedule call site that doesn't pass the new
+parameter) keeps the previous behaviour exactly — a NULL value tells
+the worker to use its own default.
+
+Schema impact on populated tables is intentionally minimal: PostgreSQL
+11+ treats ``ADD COLUMN ... DEFAULT NULL`` as a catalog-only operation
+(no table rewrite, brief ACCESS EXCLUSIVE lock on the system catalog
+row, typically < 100 ms even for tables with millions of rows). No
+backfill — NULL is the intended default.
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "aee3e8e7e647"
+down_revision: Union[str, Sequence[str], None] = "c3d4e5f6a7b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add the nullable ``max_runtime_seconds`` column to both task tables."""
+    op.add_column(
+        "pq_tasks",
+        sa.Column("max_runtime_seconds", sa.Float(), nullable=True),
+    )
+    op.add_column(
+        "pq_periodic",
+        sa.Column("max_runtime_seconds", sa.Float(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Remove the ``max_runtime_seconds`` column from both task tables."""
+    op.drop_column("pq_periodic", "max_runtime_seconds")
+    op.drop_column("pq_tasks", "max_runtime_seconds")

--- a/src/pq/models.py
+++ b/src/pq/models.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
     Boolean,
     DateTime,
     Enum,
+    Float,
     Identity,
     Index,
     Integer,
@@ -70,6 +71,14 @@ class Task(Base):
     )
     error: Mapped[str | None] = mapped_column(Text, nullable=True)
     attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # Per-task override of the worker-level ``max_runtime``. When NULL
+    # (the common case), the worker uses its configured default. When
+    # set, it caps this specific task's wall-clock at the given number
+    # of seconds AND extends the stale-reaper threshold proportionally
+    # (the reaper picks the larger of its global default and
+    # ``max_runtime_seconds * 2``). Useful for occasionally-long tasks
+    # in a fleet whose default is sized for typical short work.
+    max_runtime_seconds: Mapped[float | None] = mapped_column(Float, nullable=True)
 
 
 class Periodic(Base):
@@ -94,6 +103,17 @@ class Periodic(Base):
     next_run: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     max_concurrent: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
     active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
+    # Per-task override of the worker-level ``max_runtime``. Same semantics
+    # as ``Task.max_runtime_seconds`` — NULL means "use the worker's
+    # configured default", a set value caps this specific schedule's
+    # wall-clock at the given number of seconds and also extends the
+    # ``locked_until`` window (when ``max_concurrent`` is in effect) so
+    # the lock doesn't expire while the task is legitimately still
+    # running. Periodic tasks are not subject to the stale-task reaper
+    # (they're guarded by ``locked_until`` and the natural re-fire of
+    # the schedule), so this knob is purely about the per-execution
+    # wall-clock cap.
+    max_runtime_seconds: Mapped[float | None] = mapped_column(Float, nullable=True)
     last_run: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )

--- a/src/pq/worker.py
+++ b/src/pq/worker.py
@@ -596,6 +596,10 @@ def _process_one_off_task(
             name = task.name
             payload = task.payload
             task_id = task.id
+            # Per-task ``max_runtime_seconds`` (NULL → use worker default).
+            # Read while still in the session because the row is expunged
+            # below for the forked-child handoff.
+            task_max_runtime = task.max_runtime_seconds
 
             # Flush to commit status changes, then expunge for forked process
             session.flush()
@@ -604,6 +608,14 @@ def _process_one_off_task(
     except Exception as e:
         logger.error(f"Error claiming task: {e}")
         return False
+
+    # Effective per-task wall-clock ceiling: per-task value when set,
+    # otherwise the worker's configured default. The reaper applies the
+    # same rule on its own (see ``Client.reap_stale_tasks``), so the
+    # two stay in sync without the worker having to coordinate.
+    effective_max_runtime = (
+        task_max_runtime if task_max_runtime is not None else max_runtime
+    )
 
     # Phase 2: Execute handler in forked process
     start = time.perf_counter()
@@ -617,7 +629,7 @@ def _process_one_off_task(
             handler,
             args,
             kwargs,
-            max_runtime=max_runtime,
+            max_runtime=effective_max_runtime,
             task=task,
             pre_execute=pre_execute,
             post_execute=post_execute,
@@ -739,10 +751,27 @@ def _process_periodic_task(
             payload = periodic.payload
             periodic_id = periodic.id
             periodic_max_concurrent = periodic.max_concurrent
+            # Per-schedule ``max_runtime_seconds`` (NULL → use worker default).
+            # Read while still in the session because the row is expunged
+            # below for the forked-child handoff.
+            periodic_max_runtime = periodic.max_runtime_seconds
+
+            # Effective per-execution wall-clock ceiling: per-schedule value
+            # when set, otherwise the worker's configured default. Drives
+            # both the in-child timeout enforcement AND the
+            # ``locked_until`` window so the lock doesn't expire while a
+            # legitimately-long execution is still running.
+            effective_max_runtime = (
+                periodic_max_runtime
+                if periodic_max_runtime is not None
+                else max_runtime
+            )
 
             # Set lock before execution if concurrency is limited
             if periodic.max_concurrent is not None:
-                lock_duration = max_runtime if max_runtime > 0 else 3600
+                lock_duration = (
+                    effective_max_runtime if effective_max_runtime > 0 else 3600
+                )
                 periodic.locked_until = func.now() + timedelta(seconds=lock_duration)
 
             # Advance schedule BEFORE execution
@@ -769,7 +798,7 @@ def _process_periodic_task(
             handler,
             args,
             kwargs,
-            max_runtime=max_runtime,
+            max_runtime=effective_max_runtime,
             task=periodic,
             pre_execute=pre_execute,
             post_execute=post_execute,
@@ -851,6 +880,9 @@ def _claim_and_fork_one_off(
             name = task.name
             payload = task.payload
             task_id = task.id
+            # Per-task ``max_runtime_seconds`` (NULL → use worker default).
+            # Same handling as the sequential ``_process_one_off_task`` path.
+            task_max_runtime = task.max_runtime_seconds
 
             session.flush()
             session.expunge(task)
@@ -859,6 +891,10 @@ def _claim_and_fork_one_off(
         logger.error(f"Error claiming task: {e}")
         return None
 
+    effective_max_runtime = (
+        task_max_runtime if task_max_runtime is not None else max_runtime
+    )
+
     try:
         handler = resolve_function_path(name)
         args, kwargs = deserialize(payload)
@@ -866,7 +902,7 @@ def _claim_and_fork_one_off(
             handler,
             args,
             kwargs,
-            max_runtime=max_runtime,
+            max_runtime=effective_max_runtime,
             task=task,
             pre_execute=pre_execute,
             post_execute=post_execute,
@@ -934,9 +970,20 @@ def _claim_and_fork_periodic(
             payload = periodic.payload
             periodic_id = periodic.id
             periodic_max_concurrent = periodic.max_concurrent
+            # Per-schedule ``max_runtime_seconds`` (NULL → use worker default).
+            # Same handling as the sequential ``_process_periodic_task`` path.
+            periodic_max_runtime = periodic.max_runtime_seconds
+
+            effective_max_runtime = (
+                periodic_max_runtime
+                if periodic_max_runtime is not None
+                else max_runtime
+            )
 
             if periodic.max_concurrent is not None:
-                lock_duration = max_runtime if max_runtime > 0 else 3600
+                lock_duration = (
+                    effective_max_runtime if effective_max_runtime > 0 else 3600
+                )
                 periodic.locked_until = func.now() + timedelta(seconds=lock_duration)
 
             periodic.last_run = func.now()
@@ -959,7 +1006,7 @@ def _claim_and_fork_periodic(
             handler,
             args,
             kwargs,
-            max_runtime=max_runtime,
+            max_runtime=effective_max_runtime,
             task=periodic,
             pre_execute=pre_execute,
             post_execute=post_execute,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -800,6 +800,18 @@ class TestMaxRuntimeOverrideValidation:
         with pytest.raises(ValueError, match=r"max_runtime must be > 0"):
             pq.enqueue(dummy_handler, max_runtime=bad_value)
 
+    @pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
+    def test_enqueue_rejects_non_finite_max_runtime(
+        self, pq: PQ, bad_value: float
+    ) -> None:
+        """NaN and ±infinity bypass the ``<= 0`` check (``nan <= 0`` is
+        False, ``inf <= 0`` is False), but neither produces useful
+        worker behaviour — ``signal.alarm`` raises on NaN/inf, the
+        reaper's ``max_runtime * 2`` SQL produces NaN/NULL, etc.
+        Reject up front so the bug stays at the call site."""
+        with pytest.raises(ValueError, match=r"must be a finite positive"):
+            pq.enqueue(dummy_handler, max_runtime=bad_value)
+
     @pytest.mark.parametrize("bad_value", [0, -1])
     def test_upsert_rejects_non_positive_max_runtime(
         self, pq: PQ, bad_value: float
@@ -1164,16 +1176,23 @@ class TestReapStaleTasksRespectsPerTaskOverride:
         assert "Reaped: task still RUNNING" in with_msg
         assert "Reaped: task still RUNNING" in without_msg
 
-        # Per-row max_runtime_seconds value appears in each.
-        assert "max_runtime_seconds=300" in with_msg, f"expected '300' in {with_msg!r}"
-        assert "max_runtime_seconds=NULL" in without_msg, (
-            f"expected 'NULL' in {without_msg!r}"
+        # Per-row max_runtime_seconds value appears in each. Substrings
+        # anchored with trailing punctuation so ``"=300"`` doesn't also
+        # match ``"=3000"`` (defends against a future refactor that
+        # changes the per-task multiplier from 2× to e.g. 3×).
+        assert "max_runtime_seconds=300," in with_msg, (
+            f"expected 'max_runtime_seconds=300,' in {with_msg!r}"
+        )
+        assert "max_runtime_seconds=NULL," in without_msg, (
+            f"expected 'max_runtime_seconds=NULL,' in {without_msg!r}"
         )
 
         # Effective threshold reflects the reaper math: with-override
         # got max(3600, 600)=3600 s; without-override got 3600 s default.
-        assert "effective threshold=3600" in with_msg
-        assert "effective threshold=3600" in without_msg
+        # Anchor with trailing " s)" to prevent ``"=3600"`` matching
+        # ``"=36000"`` in any future format change.
+        assert "effective threshold=3600 s)" in with_msg
+        assert "effective threshold=3600 s)" in without_msg
 
 
 class TestMigrationAppliesOnPopulatedTables:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -782,11 +782,11 @@ class TestReapStaleTasks:
 
 
 class TestMaxRuntimeOverrideValidation:
-    """``max_runtime <= 0`` is rejected at the call site.
+    """``max_runtime_seconds <= 0`` is rejected at the call site.
 
-    Why fail fast: ``signal.alarm(int(max_runtime) + 1)`` would fire at
+    Why fail fast: ``signal.alarm(int(max_runtime_seconds) + 1)`` would fire at
     1 s for ``0`` and at 0 s (disabling the alarm) for negative integer
-    ≥ -1; ``max_runtime * 2`` in the reaper would make the per-row
+    ≥ -1; ``max_runtime_seconds * 2`` in the reaper would make the per-row
     threshold a no-op silently; periodic ``lock_duration``'s ``≤ 0``
     fallback to 3600 s is for the worker-level default, not a caller
     contract. None of these are useful behaviours to expose, so the
@@ -797,8 +797,8 @@ class TestMaxRuntimeOverrideValidation:
     def test_enqueue_rejects_non_positive_max_runtime(
         self, pq: PQ, bad_value: float
     ) -> None:
-        with pytest.raises(ValueError, match=r"max_runtime must be > 0"):
-            pq.enqueue(dummy_handler, max_runtime=bad_value)
+        with pytest.raises(ValueError, match=r"max_runtime_seconds must be > 0"):
+            pq.enqueue(dummy_handler, max_runtime_seconds=bad_value)
 
     @pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
     def test_enqueue_rejects_non_finite_max_runtime(
@@ -807,27 +807,29 @@ class TestMaxRuntimeOverrideValidation:
         """NaN and ±infinity bypass the ``<= 0`` check (``nan <= 0`` is
         False, ``inf <= 0`` is False), but neither produces useful
         worker behaviour — ``signal.alarm`` raises on NaN/inf, the
-        reaper's ``max_runtime * 2`` SQL produces NaN/NULL, etc.
+        reaper's ``max_runtime_seconds * 2`` SQL produces NaN/NULL, etc.
         Reject up front so the bug stays at the call site."""
         with pytest.raises(ValueError, match=r"must be a finite positive"):
-            pq.enqueue(dummy_handler, max_runtime=bad_value)
+            pq.enqueue(dummy_handler, max_runtime_seconds=bad_value)
 
     @pytest.mark.parametrize("bad_value", [0, -1])
     def test_upsert_rejects_non_positive_max_runtime(
         self, pq: PQ, bad_value: float
     ) -> None:
-        with pytest.raises(ValueError, match=r"max_runtime must be > 0"):
-            pq.upsert(dummy_handler, max_runtime=bad_value, client_id="reject-ups")
+        with pytest.raises(ValueError, match=r"max_runtime_seconds must be > 0"):
+            pq.upsert(
+                dummy_handler, max_runtime_seconds=bad_value, client_id="reject-ups"
+            )
 
     @pytest.mark.parametrize("bad_value", [0, -1])
     def test_schedule_rejects_non_positive_max_runtime(
         self, pq: PQ, bad_value: float
     ) -> None:
-        with pytest.raises(ValueError, match=r"max_runtime must be > 0"):
+        with pytest.raises(ValueError, match=r"max_runtime_seconds must be > 0"):
             pq.schedule(
                 cleanup_handler,
                 run_every=timedelta(hours=1),
-                max_runtime=bad_value,
+                max_runtime_seconds=bad_value,
             )
 
     def test_enqueue_accepts_tiny_positive_max_runtime(self, pq: PQ) -> None:
@@ -835,7 +837,7 @@ class TestMaxRuntimeOverrideValidation:
         validator. Acceptance is the contract; the worker's
         ``signal.alarm`` resolution floor is a separate concern
         (documented on the worker)."""
-        task_id = pq.enqueue(dummy_handler, max_runtime=0.001)
+        task_id = pq.enqueue(dummy_handler, max_runtime_seconds=0.001)
         with pq.session() as session:
             task = session.get(Task, task_id)
             assert task is not None
@@ -844,7 +846,7 @@ class TestMaxRuntimeOverrideValidation:
     def test_enqueue_accepts_none_explicitly(self, pq: PQ) -> None:
         """``None`` is the contract for 'use worker default' and must
         NOT raise — verifies the validator's early-return path."""
-        task_id = pq.enqueue(dummy_handler, max_runtime=None)
+        task_id = pq.enqueue(dummy_handler, max_runtime_seconds=None)
         with pq.session() as session:
             task = session.get(Task, task_id)
             assert task is not None
@@ -852,7 +854,7 @@ class TestMaxRuntimeOverrideValidation:
 
 
 class TestMaxRuntimeOverridePersistence:
-    """Tests for per-task ``max_runtime`` override storage.
+    """Tests for per-task ``max_runtime_seconds`` override storage.
 
     Verifies that ``Client.enqueue``, ``Client.upsert`` and ``Client.schedule``
     correctly persist the new ``max_runtime_seconds`` column on the
@@ -863,7 +865,7 @@ class TestMaxRuntimeOverridePersistence:
 
     def test_enqueue_persists_max_runtime_seconds(self, pq: PQ) -> None:
         task_id = pq.enqueue(
-            dummy_handler, max_runtime=172_800.0, client_id="override-enq-1"
+            dummy_handler, max_runtime_seconds=172_800.0, client_id="override-enq-1"
         )
         with pq.session() as session:
             task = session.get(Task, task_id)
@@ -882,7 +884,7 @@ class TestMaxRuntimeOverridePersistence:
 
     def test_upsert_persists_max_runtime_seconds(self, pq: PQ) -> None:
         task_id = pq.upsert(
-            dummy_handler, max_runtime=3600.0, client_id="override-ups-1"
+            dummy_handler, max_runtime_seconds=3600.0, client_id="override-ups-1"
         )
         with pq.session() as session:
             task = session.get(Task, task_id)
@@ -895,10 +897,10 @@ class TestMaxRuntimeOverridePersistence:
         can be replaced AND that re-upserting with ``None`` clears it
         back to NULL (so the same call site can opt-out later)."""
         first_id = pq.upsert(
-            dummy_handler, max_runtime=10.0, client_id="override-ups-conflict"
+            dummy_handler, max_runtime_seconds=10.0, client_id="override-ups-conflict"
         )
         second_id = pq.upsert(
-            dummy_handler, max_runtime=999.0, client_id="override-ups-conflict"
+            dummy_handler, max_runtime_seconds=999.0, client_id="override-ups-conflict"
         )
         assert first_id == second_id
         with pq.session() as session:
@@ -919,7 +921,7 @@ class TestMaxRuntimeOverridePersistence:
         periodic_id = pq.schedule(
             cleanup_handler,
             run_every=timedelta(hours=1),
-            max_runtime=7200.0,
+            max_runtime_seconds=7200.0,
             client_id="override-sched-1",
         )
         with pq.session() as session:
@@ -944,13 +946,13 @@ class TestMaxRuntimeOverridePersistence:
         pq.schedule(
             cleanup_handler,
             run_every=timedelta(hours=1),
-            max_runtime=10.0,
+            max_runtime_seconds=10.0,
             key="override-sched-conflict",
         )
         pq.schedule(
             cleanup_handler,
             run_every=timedelta(hours=1),
-            max_runtime=999.0,
+            max_runtime_seconds=999.0,
             key="override-sched-conflict",
         )
         from sqlalchemy import select
@@ -987,7 +989,7 @@ class TestReapStaleTasksRespectsPerTaskOverride:
     """
 
     def test_does_not_reap_long_task_within_per_task_threshold(self, pq: PQ) -> None:
-        """Task with ``max_runtime=3600`` (1h) started 30 min ago is NOT
+        """Task with ``max_runtime_seconds=3600`` (1h) started 30 min ago is NOT
         reaped, even when the reaper's default threshold is 10 min.
         Pre-feature, the row would have been reaped (started_at + 10min
         already past)."""
@@ -995,7 +997,9 @@ class TestReapStaleTasksRespectsPerTaskOverride:
 
         from pq.models import TaskStatus
 
-        task_id = pq.enqueue(dummy_handler, max_runtime=3600.0, client_id="long-task-1")
+        task_id = pq.enqueue(
+            dummy_handler, max_runtime_seconds=3600.0, client_id="long-task-1"
+        )
         with pq.session() as session:
             session.execute(
                 update(Task)
@@ -1022,7 +1026,9 @@ class TestReapStaleTasksRespectsPerTaskOverride:
 
         from pq.models import TaskStatus
 
-        task_id = pq.enqueue(dummy_handler, max_runtime=60.0, client_id="long-task-2")
+        task_id = pq.enqueue(
+            dummy_handler, max_runtime_seconds=60.0, client_id="long-task-2"
+        )
         # 60s budget × 2 = 120s threshold; started_at was 10 min ago.
         with pq.session() as session:
             session.execute(
@@ -1083,7 +1089,9 @@ class TestReapStaleTasksRespectsPerTaskOverride:
 
         # Tiny per-task budget (10s, so 2× = 20s) but default threshold
         # is 1h. Effective per-row = max(1h, 20s) = 1h.
-        task_id = pq.enqueue(dummy_handler, max_runtime=10.0, client_id="tiny-override")
+        task_id = pq.enqueue(
+            dummy_handler, max_runtime_seconds=10.0, client_id="tiny-override"
+        )
         with pq.session() as session:
             session.execute(
                 update(Task)
@@ -1114,11 +1122,11 @@ class TestReapStaleTasksRespectsPerTaskOverride:
         # All started 30 min ago.
         started = datetime.now(UTC) - timedelta(minutes=30)
         long_task = pq.enqueue(
-            dummy_handler, max_runtime=3600.0, client_id="mixed-long"
+            dummy_handler, max_runtime_seconds=3600.0, client_id="mixed-long"
         )
         null_task = pq.enqueue(dummy_handler, client_id="mixed-null")
         short_task = pq.enqueue(
-            dummy_handler, max_runtime=60.0, client_id="mixed-short"
+            dummy_handler, max_runtime_seconds=60.0, client_id="mixed-short"
         )
         with pq.session() as session:
             for task_id in (long_task, null_task, short_task):
@@ -1155,7 +1163,7 @@ class TestReapStaleTasksRespectsPerTaskOverride:
 
         started = datetime.now(UTC) - timedelta(hours=4)
         with_override = pq.enqueue(
-            dummy_handler, max_runtime=300.0, client_id="msg-with"
+            dummy_handler, max_runtime_seconds=300.0, client_id="msg-with"
         )
         without_override = pq.enqueue(dummy_handler, client_id="msg-without")
         with pq.session() as session:
@@ -1289,7 +1297,7 @@ class TestMigrationAppliesOnPopulatedTables:
             # the column wasn't just added but is actually wired into
             # enqueue.
             new_id = pq.enqueue(
-                dummy_handler, max_runtime=999.0, client_id="post-migration"
+                dummy_handler, max_runtime_seconds=999.0, client_id="post-migration"
             )
             with pq.session() as session:
                 new_task = session.get(Task, new_id)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -941,10 +941,12 @@ class TestMaxRuntimeOverridePersistence:
             max_runtime=999.0,
             key="override-sched-conflict",
         )
+        from sqlalchemy import select
+
         with pq.session() as session:
-            periodic = (
-                session.query(Periodic).filter_by(key="override-sched-conflict").one()
-            )
+            periodic = session.execute(
+                select(Periodic).where(Periodic.key == "override-sched-conflict")
+            ).scalar_one()
             assert periodic.max_runtime_seconds == 999.0
 
         # And clears back to NULL when the kwarg is omitted on re-schedule
@@ -954,9 +956,9 @@ class TestMaxRuntimeOverridePersistence:
             key="override-sched-conflict",
         )
         with pq.session() as session:
-            periodic = (
-                session.query(Periodic).filter_by(key="override-sched-conflict").one()
-            )
+            periodic = session.execute(
+                select(Periodic).where(Periodic.key == "override-sched-conflict")
+            ).scalar_one()
             assert periodic.max_runtime_seconds is None
 
 
@@ -1250,18 +1252,18 @@ class TestMigrationAppliesOnPopulatedTables:
             # exactly what the worker treats as "use my configured
             # default", so the migration is backwards-compatible by
             # construction.
+            from sqlalchemy import select
+
             with pq.session() as session:
-                old_task = (
-                    session.query(Task).filter_by(client_id="during-old-schema").one()
-                )
+                old_task = session.execute(
+                    select(Task).where(Task.client_id == "during-old-schema")
+                ).scalar_one()
                 assert old_task.max_runtime_seconds is None
                 assert old_task.status == TaskStatus.PENDING
 
-                old_periodic = (
-                    session.query(Periodic)
-                    .filter_by(client_id="during-old-schema-p")
-                    .one()
-                )
+                old_periodic = session.execute(
+                    select(Periodic).where(Periodic.client_id == "during-old-schema-p")
+                ).scalar_one()
                 assert old_periodic.max_runtime_seconds is None
 
             # And the override mechanic works post-upgrade — proves

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -781,6 +781,64 @@ class TestReapStaleTasks:
         assert reaped == 0
 
 
+class TestMaxRuntimeOverrideValidation:
+    """``max_runtime <= 0`` is rejected at the call site.
+
+    Why fail fast: ``signal.alarm(int(max_runtime) + 1)`` would fire at
+    1 s for ``0`` and at 0 s (disabling the alarm) for negative integer
+    ≥ -1; ``max_runtime * 2`` in the reaper would make the per-row
+    threshold a no-op silently; periodic ``lock_duration``'s ``≤ 0``
+    fallback to 3600 s is for the worker-level default, not a caller
+    contract. None of these are useful behaviours to expose, so the
+    client rejects them up front.
+    """
+
+    @pytest.mark.parametrize("bad_value", [0, 0.0, -1, -0.001, -1e9])
+    def test_enqueue_rejects_non_positive_max_runtime(
+        self, pq: PQ, bad_value: float
+    ) -> None:
+        with pytest.raises(ValueError, match=r"max_runtime must be > 0"):
+            pq.enqueue(dummy_handler, max_runtime=bad_value)
+
+    @pytest.mark.parametrize("bad_value", [0, -1])
+    def test_upsert_rejects_non_positive_max_runtime(
+        self, pq: PQ, bad_value: float
+    ) -> None:
+        with pytest.raises(ValueError, match=r"max_runtime must be > 0"):
+            pq.upsert(dummy_handler, max_runtime=bad_value, client_id="reject-ups")
+
+    @pytest.mark.parametrize("bad_value", [0, -1])
+    def test_schedule_rejects_non_positive_max_runtime(
+        self, pq: PQ, bad_value: float
+    ) -> None:
+        with pytest.raises(ValueError, match=r"max_runtime must be > 0"):
+            pq.schedule(
+                cleanup_handler,
+                run_every=timedelta(hours=1),
+                max_runtime=bad_value,
+            )
+
+    def test_enqueue_accepts_tiny_positive_max_runtime(self, pq: PQ) -> None:
+        """``0.001`` (1 ms) is a valid value — at the boundary of the
+        validator. Acceptance is the contract; the worker's
+        ``signal.alarm`` resolution floor is a separate concern
+        (documented on the worker)."""
+        task_id = pq.enqueue(dummy_handler, max_runtime=0.001)
+        with pq.session() as session:
+            task = session.get(Task, task_id)
+            assert task is not None
+            assert task.max_runtime_seconds == 0.001
+
+    def test_enqueue_accepts_none_explicitly(self, pq: PQ) -> None:
+        """``None`` is the contract for 'use worker default' and must
+        NOT raise — verifies the validator's early-return path."""
+        task_id = pq.enqueue(dummy_handler, max_runtime=None)
+        with pq.session() as session:
+            task = session.get(Task, task_id)
+            assert task is not None
+            assert task.max_runtime_seconds is None
+
+
 class TestMaxRuntimeOverridePersistence:
     """Tests for per-task ``max_runtime`` override storage.
 
@@ -1066,6 +1124,54 @@ class TestReapStaleTasksRespectsPerTaskOverride:
         assert pq.get_task(long_task).status == TaskStatus.RUNNING  # type: ignore[union-attr]
         assert pq.get_task(null_task).status == TaskStatus.FAILED  # type: ignore[union-attr]
         assert pq.get_task(short_task).status == TaskStatus.FAILED  # type: ignore[union-attr]
+
+    def test_reaper_error_message_includes_per_row_max_runtime(self, pq: PQ) -> None:
+        """The ``error`` written by the reaper names this row's own
+        ``max_runtime_seconds`` AND the effective threshold that
+        actually fired — so debugging "why did MY long-budget task
+        get reaped?" doesn't need a separate row lookup.
+
+        Two reaped rows in one call: one with a per-task override,
+        one without. The error column on each should reflect that
+        row's specific values, not a single shared message.
+        """
+        from sqlalchemy import update
+
+        from pq.models import TaskStatus
+
+        started = datetime.now(UTC) - timedelta(hours=4)
+        with_override = pq.enqueue(
+            dummy_handler, max_runtime=300.0, client_id="msg-with"
+        )
+        without_override = pq.enqueue(dummy_handler, client_id="msg-without")
+        with pq.session() as session:
+            for task_id in (with_override, without_override):
+                session.execute(
+                    update(Task)
+                    .where(Task.id == task_id)
+                    .values(status=TaskStatus.RUNNING, started_at=started)
+                )
+
+        reaped = pq.reap_stale_tasks(timedelta(hours=1))
+        assert reaped == 2
+
+        with_msg = pq.get_task(with_override).error or ""  # type: ignore[union-attr]
+        without_msg = pq.get_task(without_override).error or ""  # type: ignore[union-attr]
+
+        # Both messages start with the common prefix.
+        assert "Reaped: task still RUNNING" in with_msg
+        assert "Reaped: task still RUNNING" in without_msg
+
+        # Per-row max_runtime_seconds value appears in each.
+        assert "max_runtime_seconds=300" in with_msg, f"expected '300' in {with_msg!r}"
+        assert "max_runtime_seconds=NULL" in without_msg, (
+            f"expected 'NULL' in {without_msg!r}"
+        )
+
+        # Effective threshold reflects the reaper math: with-override
+        # got max(3600, 600)=3600 s; without-override got 3600 s default.
+        assert "effective threshold=3600" in with_msg
+        assert "effective threshold=3600" in without_msg
 
 
 class TestMigrationAppliesOnPopulatedTables:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -779,3 +779,397 @@ class TestReapStaleTasks:
         reaped = pq.reap_stale_tasks(timedelta(hours=1))
 
         assert reaped == 0
+
+
+class TestMaxRuntimeOverridePersistence:
+    """Tests for per-task ``max_runtime`` override storage.
+
+    Verifies that ``Client.enqueue``, ``Client.upsert`` and ``Client.schedule``
+    correctly persist the new ``max_runtime_seconds`` column on the
+    ``Task`` and ``Periodic`` rows. NULL when not provided (the common
+    case, which preserves pre-feature behaviour for every existing call
+    site); the supplied float when provided.
+    """
+
+    def test_enqueue_persists_max_runtime_seconds(self, pq: PQ) -> None:
+        task_id = pq.enqueue(
+            dummy_handler, max_runtime=172_800.0, client_id="override-enq-1"
+        )
+        with pq.session() as session:
+            task = session.get(Task, task_id)
+            assert task is not None
+            assert task.max_runtime_seconds == 172_800.0
+
+    def test_enqueue_without_max_runtime_stores_null(self, pq: PQ) -> None:
+        """Backward-compat: every existing enqueue call site (which never
+        passes the new kwarg) keeps producing rows with NULL in the new
+        column. That NULL is what the worker treats as 'use my default'."""
+        task_id = pq.enqueue(dummy_handler, client_id="override-enq-null")
+        with pq.session() as session:
+            task = session.get(Task, task_id)
+            assert task is not None
+            assert task.max_runtime_seconds is None
+
+    def test_upsert_persists_max_runtime_seconds(self, pq: PQ) -> None:
+        task_id = pq.upsert(
+            dummy_handler, max_runtime=3600.0, client_id="override-ups-1"
+        )
+        with pq.session() as session:
+            task = session.get(Task, task_id)
+            assert task is not None
+            assert task.max_runtime_seconds == 3600.0
+
+    def test_upsert_overwrites_max_runtime_on_conflict(self, pq: PQ) -> None:
+        """On client_id conflict, ``upsert`` rewrites every field
+        including ``max_runtime_seconds``. Verifies an existing value
+        can be replaced AND that re-upserting with ``None`` clears it
+        back to NULL (so the same call site can opt-out later)."""
+        first_id = pq.upsert(
+            dummy_handler, max_runtime=10.0, client_id="override-ups-conflict"
+        )
+        second_id = pq.upsert(
+            dummy_handler, max_runtime=999.0, client_id="override-ups-conflict"
+        )
+        assert first_id == second_id
+        with pq.session() as session:
+            task = session.get(Task, second_id)
+            assert task is not None
+            assert task.max_runtime_seconds == 999.0
+
+        # Now clear it back to NULL
+        third_id = pq.upsert(dummy_handler, client_id="override-ups-conflict")
+        assert third_id == second_id
+        with pq.session() as session:
+            task = session.get(Task, third_id)
+            assert task is not None
+            assert task.max_runtime_seconds is None
+
+    def test_schedule_persists_max_runtime_seconds(self, pq: PQ) -> None:
+        """The periodic side of the API supports the same override."""
+        periodic_id = pq.schedule(
+            cleanup_handler,
+            run_every=timedelta(hours=1),
+            max_runtime=7200.0,
+            client_id="override-sched-1",
+        )
+        with pq.session() as session:
+            periodic = session.get(Periodic, periodic_id)
+            assert periodic is not None
+            assert periodic.max_runtime_seconds == 7200.0
+
+    def test_schedule_without_max_runtime_stores_null(self, pq: PQ) -> None:
+        periodic_id = pq.schedule(
+            cleanup_handler,
+            run_every=timedelta(hours=1),
+            client_id="override-sched-null",
+        )
+        with pq.session() as session:
+            periodic = session.get(Periodic, periodic_id)
+            assert periodic is not None
+            assert periodic.max_runtime_seconds is None
+
+    def test_schedule_overwrites_max_runtime_on_conflict(self, pq: PQ) -> None:
+        """Re-scheduling the same (name, key) rewrites the override —
+        analogous to the upsert behaviour."""
+        pq.schedule(
+            cleanup_handler,
+            run_every=timedelta(hours=1),
+            max_runtime=10.0,
+            key="override-sched-conflict",
+        )
+        pq.schedule(
+            cleanup_handler,
+            run_every=timedelta(hours=1),
+            max_runtime=999.0,
+            key="override-sched-conflict",
+        )
+        with pq.session() as session:
+            periodic = (
+                session.query(Periodic).filter_by(key="override-sched-conflict").one()
+            )
+            assert periodic.max_runtime_seconds == 999.0
+
+        # And clears back to NULL when the kwarg is omitted on re-schedule
+        pq.schedule(
+            cleanup_handler,
+            run_every=timedelta(hours=1),
+            key="override-sched-conflict",
+        )
+        with pq.session() as session:
+            periodic = (
+                session.query(Periodic).filter_by(key="override-sched-conflict").one()
+            )
+            assert periodic.max_runtime_seconds is None
+
+
+class TestReapStaleTasksRespectsPerTaskOverride:
+    """Tests that the reaper SQL honours per-task ``max_runtime_seconds``.
+
+    The reaper takes a default ``threshold`` (used for tasks without
+    an override) and switches to ``max(default_threshold, 2 *
+    max_runtime_seconds)`` per row. This means a legitimately
+    long-running task that declared a big budget is NOT reaped before
+    the budget * 2 elapses — even if the worker default would have
+    reaped it sooner. Tasks without an override keep the previous
+    behaviour exactly.
+    """
+
+    def test_does_not_reap_long_task_within_per_task_threshold(self, pq: PQ) -> None:
+        """Task with ``max_runtime=3600`` (1h) started 30 min ago is NOT
+        reaped, even when the reaper's default threshold is 10 min.
+        Pre-feature, the row would have been reaped (started_at + 10min
+        already past)."""
+        from sqlalchemy import update
+
+        from pq.models import TaskStatus
+
+        task_id = pq.enqueue(dummy_handler, max_runtime=3600.0, client_id="long-task-1")
+        with pq.session() as session:
+            session.execute(
+                update(Task)
+                .where(Task.id == task_id)
+                .values(
+                    status=TaskStatus.RUNNING,
+                    started_at=datetime.now(UTC) - timedelta(minutes=30),
+                )
+            )
+
+        # Default threshold = 10 min. The per-task budget * 2 = 2h, so
+        # the row's effective threshold is 2h, and 30 min < 2h → not stale.
+        reaped = pq.reap_stale_tasks(timedelta(minutes=10))
+
+        assert reaped == 0
+        task = pq.get_task(task_id)
+        assert task is not None
+        assert task.status == TaskStatus.RUNNING
+
+    def test_reaps_long_task_once_per_task_threshold_elapses(self, pq: PQ) -> None:
+        """Same task as above, but started long enough ago to exceed
+        ``2 * max_runtime_seconds``: gets reaped."""
+        from sqlalchemy import update
+
+        from pq.models import TaskStatus
+
+        task_id = pq.enqueue(dummy_handler, max_runtime=60.0, client_id="long-task-2")
+        # 60s budget × 2 = 120s threshold; started_at was 10 min ago.
+        with pq.session() as session:
+            session.execute(
+                update(Task)
+                .where(Task.id == task_id)
+                .values(
+                    status=TaskStatus.RUNNING,
+                    started_at=datetime.now(UTC) - timedelta(minutes=10),
+                )
+            )
+
+        # Default threshold = 1 min. Per-task threshold = 2 min.
+        # Effective per-row = max(1, 2) = 2 min. 10 min > 2 min → reaped.
+        reaped = pq.reap_stale_tasks(timedelta(minutes=1))
+
+        assert reaped == 1
+        task = pq.get_task(task_id)
+        assert task is not None
+        assert task.status == TaskStatus.FAILED
+
+    def test_reaps_unoverridden_task_with_default_threshold(self, pq: PQ) -> None:
+        """Task without ``max_runtime_seconds`` (NULL): the reaper falls
+        back to the supplied default threshold. This is the
+        backward-compat path — covers every existing call site that
+        doesn't pass the new kwarg."""
+        from sqlalchemy import update
+
+        from pq.models import TaskStatus
+
+        task_id = pq.enqueue(dummy_handler, client_id="null-override-stale")
+        with pq.session() as session:
+            session.execute(
+                update(Task)
+                .where(Task.id == task_id)
+                .values(
+                    status=TaskStatus.RUNNING,
+                    started_at=datetime.now(UTC) - timedelta(hours=2),
+                )
+            )
+
+        reaped = pq.reap_stale_tasks(timedelta(hours=1))
+
+        assert reaped == 1
+        task = pq.get_task(task_id)
+        assert task is not None
+        assert task.status == TaskStatus.FAILED
+
+    def test_default_threshold_acts_as_floor_when_larger_than_per_task(
+        self, pq: PQ
+    ) -> None:
+        """When the supplied default threshold is LARGER than ``2 *
+        per_task``, the default still applies. This prevents a tiny
+        per-task budget from accidentally tightening the reaper window
+        below what the worker fleet expects."""
+        from sqlalchemy import update
+
+        from pq.models import TaskStatus
+
+        # Tiny per-task budget (10s, so 2× = 20s) but default threshold
+        # is 1h. Effective per-row = max(1h, 20s) = 1h.
+        task_id = pq.enqueue(dummy_handler, max_runtime=10.0, client_id="tiny-override")
+        with pq.session() as session:
+            session.execute(
+                update(Task)
+                .where(Task.id == task_id)
+                .values(
+                    status=TaskStatus.RUNNING,
+                    started_at=datetime.now(UTC) - timedelta(minutes=30),
+                )
+            )
+
+        # 30 min < 1h default → not reaped (despite per-task * 2 = 20s
+        # being exceeded), because the default is the floor.
+        reaped = pq.reap_stale_tasks(timedelta(hours=1))
+
+        assert reaped == 0
+        task = pq.get_task(task_id)
+        assert task is not None
+        assert task.status == TaskStatus.RUNNING
+
+    def test_mixed_tasks_reaped_independently(self, pq: PQ) -> None:
+        """A batch with mixed overrides — verifies the reaper applies
+        the per-row condition correctly, not a single threshold across
+        all rows."""
+        from sqlalchemy import update
+
+        from pq.models import TaskStatus
+
+        # All started 30 min ago.
+        started = datetime.now(UTC) - timedelta(minutes=30)
+        long_task = pq.enqueue(
+            dummy_handler, max_runtime=3600.0, client_id="mixed-long"
+        )
+        null_task = pq.enqueue(dummy_handler, client_id="mixed-null")
+        short_task = pq.enqueue(
+            dummy_handler, max_runtime=60.0, client_id="mixed-short"
+        )
+        with pq.session() as session:
+            for task_id in (long_task, null_task, short_task):
+                session.execute(
+                    update(Task)
+                    .where(Task.id == task_id)
+                    .values(status=TaskStatus.RUNNING, started_at=started)
+                )
+
+        # Default threshold = 10 min.
+        # long_task: per-row = max(10min, 2h) = 2h → 30min < 2h, NOT reaped
+        # null_task: per-row = 10min default → 30min > 10min, REAPED
+        # short_task: per-row = max(10min, 2min) = 10min → 30min > 10min, REAPED
+        reaped = pq.reap_stale_tasks(timedelta(minutes=10))
+
+        assert reaped == 2
+        assert pq.get_task(long_task).status == TaskStatus.RUNNING  # type: ignore[union-attr]
+        assert pq.get_task(null_task).status == TaskStatus.FAILED  # type: ignore[union-attr]
+        assert pq.get_task(short_task).status == TaskStatus.FAILED  # type: ignore[union-attr]
+
+
+class TestMigrationAppliesOnPopulatedTables:
+    """Verifies the ``aee3e8e7e647`` migration applies cleanly to
+    already-populated ``pq_tasks`` and ``pq_periodic`` tables and
+    leaves all existing rows intact with NULL in the new column.
+
+    This is the deployment-time scenario: production pq_tasks already
+    has thousands of rows (the worker fleet is running, customers are
+    enqueueing) when the migration runs. The migration must not lose
+    or rewrite data.
+    """
+
+    def test_migration_downgrade_then_upgrade_preserves_rows(
+        self, pq: PQ, db_url: str
+    ) -> None:
+        from alembic import command
+        from alembic.config import Config
+        import importlib.resources
+
+        from pq.models import TaskStatus
+
+        migrations_pkg = importlib.resources.files("pq.migrations")
+        cfg = Config()
+        cfg.set_main_option("script_location", str(migrations_pkg))
+        cfg.set_main_option("sqlalchemy.url", db_url)
+
+        # The ``pq`` fixture uses ``create_tables()`` (which bypasses
+        # Alembic), so the ``pq_schema_version`` tracking table doesn't
+        # exist yet. Stamp at head so the migration history matches the
+        # schema before we exercise the downgrade → upgrade cycle.
+        command.stamp(cfg, "head")
+
+        # The schema gets downgraded mid-test. Wrap the whole flow in
+        # try/finally so a failed assertion below doesn't leave the
+        # shared test database (per-session, not per-test) without the
+        # ``max_runtime_seconds`` column — that would cascade-fail every
+        # subsequent test in the suite that touches pq_tasks / pq_periodic.
+        try:
+            # Downgrade past our migration — simulates a production database
+            # at the previous head before this PR is deployed.
+            command.downgrade(cfg, "-1")
+
+            # Insert rows under the OLD schema (no max_runtime_seconds
+            # column). Real-world deployment shape — production already
+            # has thousands of rows when the migration is applied. Use
+            # raw SQL with the enum NAMES (``'PENDING'``) because the
+            # Postgres enum stores names not values (see
+            # ``initial_schema`` migration: ``sa.Enum("PENDING", ...)``).
+            from sqlalchemy import text
+
+            with pq.session() as session:
+                session.execute(
+                    text(
+                        "INSERT INTO pq_tasks (name, payload, priority, status,"
+                        " run_at, client_id, attempts) VALUES (:name,"
+                        " '{}'::jsonb, 50, 'PENDING', now(), :client_id, 0)"
+                    ),
+                    {"name": "tests.dummy", "client_id": "during-old-schema"},
+                )
+                session.execute(
+                    text(
+                        "INSERT INTO pq_periodic (name, key, payload, priority,"
+                        " run_every, next_run, client_id, active) VALUES"
+                        " (:name, '', '{}'::jsonb, 50, '1 hour'::interval,"
+                        " now(), :client_id, true)"
+                    ),
+                    {"name": "tests.dummy", "client_id": "during-old-schema-p"},
+                )
+
+            # Upgrade again — the real production migration path.
+            command.upgrade(cfg, "head")
+
+            # Rows seeded under the old schema must survive intact AND
+            # now have a NULL value in the newly-added column. NULL is
+            # exactly what the worker treats as "use my configured
+            # default", so the migration is backwards-compatible by
+            # construction.
+            with pq.session() as session:
+                old_task = (
+                    session.query(Task).filter_by(client_id="during-old-schema").one()
+                )
+                assert old_task.max_runtime_seconds is None
+                assert old_task.status == TaskStatus.PENDING
+
+                old_periodic = (
+                    session.query(Periodic)
+                    .filter_by(client_id="during-old-schema-p")
+                    .one()
+                )
+                assert old_periodic.max_runtime_seconds is None
+
+            # And the override mechanic works post-upgrade — proves
+            # the column wasn't just added but is actually wired into
+            # enqueue.
+            new_id = pq.enqueue(
+                dummy_handler, max_runtime=999.0, client_id="post-migration"
+            )
+            with pq.session() as session:
+                new_task = session.get(Task, new_id)
+                assert new_task is not None
+                assert new_task.max_runtime_seconds == 999.0
+        finally:
+            # Belt-and-braces: even if any assertion above raised, push
+            # the schema back to head before this test releases its
+            # session. Subsequent tests assume head schema.
+            command.upgrade(cfg, "head")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -99,6 +99,29 @@ def slow_sync_handler() -> None:
     time.sleep(10)
 
 
+def lock_observer_handler(db_url: str) -> None:
+    """Handler used by ``test_periodic_lock_duration_scales_with_per_task_max_runtime``.
+
+    Queries its own periodic row mid-execution (before the
+    post-execution cleanup at ``worker.py:833`` clears ``locked_until``)
+    and stores the captured value into the test's shared
+    multiprocessing list. Runs in a forked child, so it opens its own
+    short-lived ``PQ`` client against the supplied ``db_url`` rather
+    than trying to reuse the parent's session.
+    """
+    from sqlalchemy import select
+
+    from pq.client import PQ as PQClient
+
+    client = PQClient(db_url)
+    try:
+        with client.session() as session:
+            periodic = session.execute(select(Periodic)).scalar_one()
+            _shared_results.append(periodic.locked_until)
+    finally:
+        client.close()
+
+
 def sleep_handler(duration: float) -> None:
     """Sleep for a given duration. Used in concurrency tests."""
     time.sleep(duration)
@@ -1173,3 +1196,151 @@ class TestStaleReaperRace:
         assert task is not None
         assert task.status == TaskStatus.FAILED
         assert "Reaped" in (task.error or "")
+
+
+class TestPerTaskMaxRuntimeEnforcement:
+    """Tests that the worker honours per-task ``max_runtime_seconds`` on
+    every execution path (sequential + concurrent × one-off + periodic).
+
+    Each test pins one knob and varies the other, asserting the worker
+    picks the right effective ceiling:
+
+    - per-task value when set
+    - worker default when per-task is NULL (backwards-compat)
+    """
+
+    # ------------------------------------------------------------------
+    # One-off tasks — sequential path (``_process_one_off_task``)
+    # ------------------------------------------------------------------
+
+    def test_one_off_async_task_uses_per_task_max_runtime(self, pq: PQ) -> None:
+        """Per-task override TIGHTER than worker default kills the task."""
+        # Worker default = 30s, per-task = 0.1s → killed at 0.1s.
+        pq.enqueue(slow_async_handler, max_runtime=0.1)
+        pq.run_worker_once(max_runtime=30)
+        assert pq.pending_count() == 0  # task processed (and failed)
+
+    def test_one_off_sync_task_uses_per_task_max_runtime(self, pq: PQ) -> None:
+        """Same as above for sync handlers (SIGALRM path)."""
+        # SIGALRM has 1-second granularity; use 1s for the override
+        # and 60s for the worker default.
+        pq.enqueue(slow_sync_handler, max_runtime=1)
+        pq.run_worker_once(max_runtime=60)
+        assert pq.pending_count() == 0
+
+    def test_one_off_task_falls_back_to_worker_default_when_null(self, pq: PQ) -> None:
+        """Backwards-compat: enqueue without override → worker default
+        applies (so existing call sites keep their previous semantics
+        exactly)."""
+        # No per-task value; worker default = 0.1s → still killed.
+        pq.enqueue(slow_async_handler)
+        pq.run_worker_once(max_runtime=0.1)
+        assert pq.pending_count() == 0
+
+    def test_one_off_task_override_can_be_longer_than_worker_default(
+        self, pq: PQ
+    ) -> None:
+        """Per-task override LOOSER than worker default lets a fast task
+        complete normally even when the worker's general policy is
+        aggressive. This is THE central use case — a worker fleet
+        sized for short tasks lets one occasionally-long task opt out
+        of the tight ceiling."""
+        # Worker default = 0.5s. Fast handler completes in ~0s; we
+        # pass max_runtime=10 just to prove the override is honoured
+        # (else the task would be killed even though it's fast — no:
+        # fast tasks aren't affected by either ceiling; what we're
+        # really proving is the column is consumed by the right code
+        # path without breaking happy-path execution).
+        pq.enqueue(noop_handler, max_runtime=10.0)
+        result = pq.run_worker_once(max_runtime=0.5)
+        assert result is True  # task was processed
+        assert pq.pending_count() == 0
+
+    # ------------------------------------------------------------------
+    # Periodic tasks — sequential path (``_process_periodic_task``)
+    # ------------------------------------------------------------------
+
+    def test_periodic_async_task_uses_per_task_max_runtime(self, pq: PQ) -> None:
+        """Same as one-off but on the periodic path. The periodic
+        worker reads ``periodic.max_runtime_seconds`` and applies the
+        same effective-value rule."""
+        pq.schedule(
+            slow_async_handler,
+            run_every=timedelta(seconds=60),
+            max_runtime=0.1,
+        )
+        pq.run_worker_once(max_runtime=30)
+        # Periodic doesn't pop from pending_count; assert via the
+        # schedule's last_run timestamp moving forward.
+        from sqlalchemy import select
+
+        with pq.session() as session:
+            periodic = session.execute(select(Periodic)).scalar_one()
+            assert periodic.last_run is not None
+
+    def test_periodic_task_falls_back_to_worker_default_when_null(self, pq: PQ) -> None:
+        """Backwards-compat for the periodic path."""
+        pq.schedule(slow_async_handler, run_every=timedelta(seconds=60))
+        pq.run_worker_once(max_runtime=0.1)  # worker default kills it
+        from sqlalchemy import select
+
+        with pq.session() as session:
+            periodic = session.execute(select(Periodic)).scalar_one()
+            assert periodic.last_run is not None
+
+    def test_periodic_lock_duration_scales_with_per_task_max_runtime(
+        self,
+        pq: PQ,
+        db_url: str,
+        manager: multiprocessing.managers.SyncManager,
+    ) -> None:
+        """When ``max_concurrent=1``, the worker sets
+        ``locked_until = now() + lock_duration`` to keep concurrent
+        workers off the schedule during execution. That lock duration
+        must track the per-task override, not the worker default —
+        otherwise a long-running periodic would lose its lock
+        mid-execution and another worker could claim it.
+
+        Verifies by capturing ``locked_until`` from inside the forked
+        handler (via shared multiprocessing state) before the
+        post-execution cleanup at ``worker.py:833`` clears it back to
+        ``None``. Asserts the captured window is far closer to the
+        per-task override (120 s) than the worker default (30 s).
+        """
+        captured = manager.list()
+        _set_shared_results(captured)
+
+        pq.schedule(
+            lock_observer_handler,
+            db_url=db_url,
+            run_every=timedelta(seconds=60),
+            max_concurrent=1,
+            max_runtime=120.0,
+        )
+        pq.run_worker_once(max_runtime=30.0)
+
+        # Handler ran once and captured ``locked_until`` it observed for
+        # its own row, before the post-execution cleanup cleared the lock.
+        assert len(captured) == 1, (
+            f"lock_observer_handler should have run exactly once; "
+            f"got {len(captured)} captures"
+        )
+        locked_until = captured[0]
+        assert locked_until is not None, (
+            "locked_until was None at execution time — concurrency lock "
+            "was never set despite max_concurrent=1"
+        )
+        # The captured ``locked_until`` was set ~now()+lock_duration just
+        # before the fork; ``now()`` here is mid- to post-fork. The window
+        # should be well above the worker default (30 s) and bounded above
+        # by the per-task override (120 s) plus measurement slack.
+        window_seconds = (locked_until - datetime.now(UTC)).total_seconds()
+        assert window_seconds > 60.0, (
+            f"Lock window {window_seconds:.1f}s is suspiciously short — "
+            f"likely fell back to the worker default (30s) instead of "
+            f"honouring the per-task override (120s)."
+        )
+        assert window_seconds < 180.0, (
+            f"Lock window {window_seconds:.1f}s exceeds the per-task "
+            f"override + measurement slack."
+        )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -103,7 +103,7 @@ async def tracked_slow_async_handler() -> None:
     """Slow async handler that appends ``"completed"`` to shared state
     only AFTER the sleep finishes.
 
-    Tests of "the per-task ``max_runtime`` killed the execution" assert
+    Tests of "the per-task ``max_runtime_seconds`` killed the execution" assert
     the absence of this marker — if the worker honoured the override
     (e.g. 1 s cap), ``asyncio.wait_for`` cancels the coroutine before
     the append; if it ignored the override and let the 10 s sleep
@@ -997,7 +997,7 @@ class TestConcurrentWorker:
         assert len(pq.list_completed()) == 3
 
     def test_timeout_concurrent(self, pq: PQ, db_url: str) -> None:
-        """Task exceeding max_runtime is killed and marked failed."""
+        """Task exceeding max_runtime_seconds is killed and marked failed."""
         pq.enqueue(slow_sync_handler)  # sleeps 10s
 
         pid, _ = self._run_concurrent_worker(db_url, max_runtime=1)
@@ -1167,7 +1167,7 @@ class TestConcurrentWorker:
         assert len(pq.list_completed()) == 1
 
     # ------------------------------------------------------------------
-    # Per-task max_runtime override — concurrent paths
+    # Per-task max_runtime_seconds override — concurrent paths
     # ------------------------------------------------------------------
     # Cover the ``_claim_and_fork_one_off`` and ``_claim_and_fork_periodic``
     # code paths (``worker.py:844, 933``) which mirror the sequential
@@ -1180,9 +1180,9 @@ class TestConcurrentWorker:
     def test_one_off_per_task_max_runtime_honored_concurrent(
         self, pq: PQ, db_url: str
     ) -> None:
-        """Per-task ``max_runtime=1`` kills a slow task even when the
+        """Per-task ``max_runtime_seconds=1`` kills a slow task even when the
         concurrent worker's own default is loose (60 s)."""
-        pq.enqueue(slow_sync_handler, max_runtime=1)
+        pq.enqueue(slow_sync_handler, max_runtime_seconds=1)
 
         pid, _ = self._run_concurrent_worker(db_url, max_runtime=60)
         self._wait_for(lambda: len(pq.list_failed()) >= 1, timeout=15)
@@ -1209,7 +1209,7 @@ class TestConcurrentWorker:
         ABSENCE of the post-sleep marker — direct proof the kill
         happened. ``last_run`` alone is set by the worker before the
         fork (Phase 1), so it doesn't differentiate "killed by
-        per-task max_runtime" from "ran to completion"."""
+        per-task max_runtime_seconds" from "ran to completion"."""
         from sqlalchemy import select
 
         results = manager.list()
@@ -1218,7 +1218,7 @@ class TestConcurrentWorker:
         pq.schedule(
             tracked_slow_async_handler,
             run_every=timedelta(seconds=60),
-            max_runtime=1.0,
+            max_runtime_seconds=1.0,
         )
 
         pid, _ = self._run_concurrent_worker(db_url, max_runtime=60)
@@ -1243,7 +1243,7 @@ class TestConcurrentWorker:
         self._stop_worker(pid)
 
         assert list(results) == [], (
-            f"per-task max_runtime=1.0 on the concurrent periodic path "
+            f"per-task max_runtime_seconds=1.0 on the concurrent periodic path "
             f"should have killed the handler before its 10 s sleep "
             f"finished; got results={list(results)} (handler ran to "
             f"completion → override was ignored)"
@@ -1327,7 +1327,7 @@ class TestPerTaskMaxRuntimeEnforcement:
     def test_one_off_async_task_uses_per_task_max_runtime(self, pq: PQ) -> None:
         """Per-task override TIGHTER than worker default kills the task."""
         # Worker default = 30s, per-task = 0.1s → killed at 0.1s.
-        pq.enqueue(slow_async_handler, max_runtime=0.1)
+        pq.enqueue(slow_async_handler, max_runtime_seconds=0.1)
         pq.run_worker_once(max_runtime=30)
         assert pq.pending_count() == 0  # task processed (and failed)
 
@@ -1335,7 +1335,7 @@ class TestPerTaskMaxRuntimeEnforcement:
         """Same as above for sync handlers (SIGALRM path)."""
         # SIGALRM has 1-second granularity; use 1s for the override
         # and 60s for the worker default.
-        pq.enqueue(slow_sync_handler, max_runtime=1)
+        pq.enqueue(slow_sync_handler, max_runtime_seconds=1)
         pq.run_worker_once(max_runtime=60)
         assert pq.pending_count() == 0
 
@@ -1357,12 +1357,12 @@ class TestPerTaskMaxRuntimeEnforcement:
         sized for short tasks lets one occasionally-long task opt out
         of the tight ceiling."""
         # Worker default = 0.5s. Fast handler completes in ~0s; we
-        # pass max_runtime=10 just to prove the override is honoured
+        # pass max_runtime_seconds=10 just to prove the override is honoured
         # (else the task would be killed even though it's fast — no:
         # fast tasks aren't affected by either ceiling; what we're
         # really proving is the column is consumed by the right code
         # path without breaking happy-path execution).
-        pq.enqueue(noop_handler, max_runtime=10.0)
+        pq.enqueue(noop_handler, max_runtime_seconds=10.0)
         result = pq.run_worker_once(max_runtime=0.5)
         assert result is True  # task was processed
         assert pq.pending_count() == 0
@@ -1389,12 +1389,12 @@ class TestPerTaskMaxRuntimeEnforcement:
         pq.schedule(
             tracked_slow_async_handler,
             run_every=timedelta(seconds=60),
-            max_runtime=0.1,
+            max_runtime_seconds=0.1,
         )
         pq.run_worker_once(max_runtime=30)
 
         assert list(results) == [], (
-            f"per-task max_runtime=0.1 should have killed the handler "
+            f"per-task max_runtime_seconds=0.1 should have killed the handler "
             f"before its 10 s sleep finished; got results={list(results)}"
         )
 
@@ -1441,7 +1441,7 @@ class TestPerTaskMaxRuntimeEnforcement:
             db_url=db_url,
             run_every=timedelta(seconds=60),
             max_concurrent=1,
-            max_runtime=120.0,
+            max_runtime_seconds=120.0,
         )
         pq.run_worker_once(max_runtime=30.0)
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -100,14 +100,26 @@ def slow_sync_handler() -> None:
 
 
 def lock_observer_handler(db_url: str) -> None:
-    """Handler used by ``test_periodic_lock_duration_scales_with_per_task_max_runtime``.
+    """Handler used by
+    ``test_periodic_lock_duration_scales_with_per_task_max_runtime``.
 
-    Queries its own periodic row mid-execution (before the
-    post-execution cleanup at ``worker.py:833`` clears ``locked_until``)
-    and stores the captured value into the test's shared
-    multiprocessing list. Runs in a forked child, so it opens its own
-    short-lived ``PQ`` client against the supplied ``db_url`` rather
-    than trying to reuse the parent's session.
+    The periodic worker sets ``locked_until = func.now() +
+    interval`` BEFORE forking (a SQL expression — not a Python
+    datetime), then clears it back to ``None`` after the task
+    finishes (``worker.py:833``). Two consequences for the test:
+
+    1. After ``run_worker_once`` returns, ``locked_until`` is back
+       to ``None`` — too late to observe.
+    2. A simpler ``pre_execute`` hook approach (read
+       ``task.locked_until`` from the periodic object passed in)
+       doesn't work either: the value is an unresolved SQLAlchemy
+       expression on the expunged row, and trying to read it raises
+       ``DetachedInstanceError`` because the lazy-load needs a
+       session.
+
+    So the only viable observation point is mid-handler, in the
+    forked child, with a freshly-opened session that re-queries
+    the row.
     """
     from sqlalchemy import select
 
@@ -1371,11 +1383,9 @@ class TestPerTaskMaxRuntimeEnforcement:
         otherwise a long-running periodic would lose its lock
         mid-execution and another worker could claim it.
 
-        Verifies by capturing ``locked_until`` from inside the forked
-        handler (via shared multiprocessing state) before the
-        post-execution cleanup at ``worker.py:833`` clears it back to
-        ``None``. Asserts the captured window is far closer to the
-        per-task override (120 s) than the worker default (30 s).
+        See ``lock_observer_handler`` for why the observation has to
+        happen mid-handler with a fresh DB query rather than via a
+        ``pre_execute`` hook or a post-run inspection.
         """
         captured = manager.list()
         _set_shared_results(captured)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1138,6 +1138,76 @@ class TestConcurrentWorker:
         assert list(results) == [42]
         assert len(pq.list_completed()) == 1
 
+    # ------------------------------------------------------------------
+    # Per-task max_runtime override — concurrent paths
+    # ------------------------------------------------------------------
+    # Cover the ``_claim_and_fork_one_off`` and ``_claim_and_fork_periodic``
+    # code paths (``worker.py:844, 933``) which mirror the sequential
+    # ``_process_one_off_task`` / ``_process_periodic_task`` logic but
+    # are reached only under ``concurrency > 1``. Without these, a
+    # regression in the concurrent fork-claim path (where the per-task
+    # value is read off the row before ``session.expunge``) would slip
+    # past the sequential tests in ``TestPerTaskMaxRuntimeEnforcement``.
+
+    def test_one_off_per_task_max_runtime_honored_concurrent(
+        self, pq: PQ, db_url: str
+    ) -> None:
+        """Per-task ``max_runtime=1`` kills a slow task even when the
+        concurrent worker's own default is loose (60 s)."""
+        pq.enqueue(slow_sync_handler, max_runtime=1)
+
+        pid, _ = self._run_concurrent_worker(db_url, max_runtime=60)
+        self._wait_for(lambda: len(pq.list_failed()) >= 1, timeout=15)
+        self._stop_worker(pid)
+
+        failed = pq.list_failed()
+        assert len(failed) == 1
+        # Per-task value WAS honored: task died at ~1 s despite worker
+        # default of 60 s. If the concurrent claim path forgot to read
+        # ``max_runtime_seconds``, we'd hit the 10 s sleep instead and
+        # this assertion would time out long before failure.
+        assert "Timed out" in (failed[0].error or "")
+        assert failed[0].max_runtime_seconds == 1.0
+
+    def test_periodic_per_task_max_runtime_honored_concurrent(
+        self,
+        pq: PQ,
+        db_url: str,
+        manager: multiprocessing.managers.SyncManager,
+    ) -> None:
+        """Same as above but on the periodic concurrent path."""
+        from sqlalchemy import select
+
+        pq.schedule(
+            slow_async_handler,
+            run_every=timedelta(seconds=60),
+            max_runtime=1.0,
+        )
+
+        pid, _ = self._run_concurrent_worker(db_url, max_runtime=60)
+
+        # Wait for the periodic to fire once — ``last_run`` advances
+        # whether the execution succeeds or times out, so it's a clean
+        # signal that the worker processed (and per-task max_runtime
+        # killed) the execution.
+        def _periodic_fired() -> bool:
+            with pq.session() as session:
+                p = session.execute(select(Periodic)).scalar_one()
+                return p.last_run is not None
+
+        self._wait_for(_periodic_fired, timeout=15)
+        self._stop_worker(pid)
+
+        # If the concurrent periodic claim path forgot to read
+        # ``max_runtime_seconds``, the worker's 60 s default would let
+        # the 10 s slow_async sleep run to completion. With the
+        # per-task value applied, the asyncio.wait_for fires at 1 s
+        # and the task is killed.
+        with pq.session() as session:
+            p = session.execute(select(Periodic)).scalar_one()
+            assert p.max_runtime_seconds == 1.0
+            assert p.last_run is not None
+
 
 class TestStaleReaperRace:
     """Tests for the Phase 3 race between worker status update and reaper."""

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -99,6 +99,22 @@ def slow_sync_handler() -> None:
     time.sleep(10)
 
 
+async def tracked_slow_async_handler() -> None:
+    """Slow async handler that appends ``"completed"`` to shared state
+    only AFTER the sleep finishes.
+
+    Tests of "the per-task ``max_runtime`` killed the execution" assert
+    the absence of this marker — if the worker honoured the override
+    (e.g. 1 s cap), ``asyncio.wait_for`` cancels the coroutine before
+    the append; if it ignored the override and let the 10 s sleep
+    finish, the marker is written. This is stronger than asserting
+    ``periodic.last_run is not None``, because ``last_run`` is set
+    by the worker BEFORE the fork (Phase 1 — claim), independent of
+    whether the handler runs to completion."""
+    await asyncio.sleep(10)
+    _shared_results.append("completed")
+
+
 def lock_observer_handler(db_url: str) -> None:
     """Handler used by
     ``test_periodic_lock_duration_scales_with_per_task_max_runtime``.
@@ -1187,38 +1203,51 @@ class TestConcurrentWorker:
         db_url: str,
         manager: multiprocessing.managers.SyncManager,
     ) -> None:
-        """Same as above but on the periodic concurrent path."""
+        """Same as above but on the periodic concurrent path.
+
+        Uses ``tracked_slow_async_handler`` so we can assert on the
+        ABSENCE of the post-sleep marker — direct proof the kill
+        happened. ``last_run`` alone is set by the worker before the
+        fork (Phase 1), so it doesn't differentiate "killed by
+        per-task max_runtime" from "ran to completion"."""
         from sqlalchemy import select
 
+        results = manager.list()
+        _set_shared_results(results)
+
         pq.schedule(
-            slow_async_handler,
+            tracked_slow_async_handler,
             run_every=timedelta(seconds=60),
             max_runtime=1.0,
         )
 
         pid, _ = self._run_concurrent_worker(db_url, max_runtime=60)
 
-        # Wait for the periodic to fire once — ``last_run`` advances
-        # whether the execution succeeds or times out, so it's a clean
-        # signal that the worker processed (and per-task max_runtime
-        # killed) the execution.
+        # Wait until the worker has claimed AND processed the
+        # periodic. ``last_run`` advances at claim time (before fork),
+        # so it tells us "claim happened" — necessary precondition for
+        # the kill-or-not check below. We then wait a small grace
+        # period for the forked child to finish its 1 s timeout cycle
+        # (and, if the override was ignored, complete its 10 s sleep).
         def _periodic_fired() -> bool:
             with pq.session() as session:
                 p = session.execute(select(Periodic)).scalar_one()
                 return p.last_run is not None
 
         self._wait_for(_periodic_fired, timeout=15)
+        # Wait long enough that BOTH outcomes would have completed:
+        # - kill at ~1 s (override honoured): no marker written
+        # - 10 s sleep finishes (override ignored): marker written
+        # 13 s is past the 10 s sleep + post-execute lifecycle.
+        time.sleep(13)
         self._stop_worker(pid)
 
-        # If the concurrent periodic claim path forgot to read
-        # ``max_runtime_seconds``, the worker's 60 s default would let
-        # the 10 s slow_async sleep run to completion. With the
-        # per-task value applied, the asyncio.wait_for fires at 1 s
-        # and the task is killed.
-        with pq.session() as session:
-            p = session.execute(select(Periodic)).scalar_one()
-            assert p.max_runtime_seconds == 1.0
-            assert p.last_run is not None
+        assert list(results) == [], (
+            f"per-task max_runtime=1.0 on the concurrent periodic path "
+            f"should have killed the handler before its 10 s sleep "
+            f"finished; got results={list(results)} (handler ran to "
+            f"completion → override was ignored)"
+        )
 
 
 class TestStaleReaperRace:
@@ -1342,33 +1371,50 @@ class TestPerTaskMaxRuntimeEnforcement:
     # Periodic tasks — sequential path (``_process_periodic_task``)
     # ------------------------------------------------------------------
 
-    def test_periodic_async_task_uses_per_task_max_runtime(self, pq: PQ) -> None:
-        """Same as one-off but on the periodic path. The periodic
-        worker reads ``periodic.max_runtime_seconds`` and applies the
-        same effective-value rule."""
+    def test_periodic_async_task_uses_per_task_max_runtime(
+        self, pq: PQ, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """Per-task override TIGHTER than worker default kills the
+        periodic handler before it can write the "completed" marker.
+
+        Asserting on the absence of the marker proves the kill
+        actually happened. (Earlier weaker version asserted
+        ``last_run is not None``, but the worker sets ``last_run``
+        BEFORE the fork — independent of whether the handler runs to
+        completion. The marker is set AFTER the slow sleep, so its
+        absence is a real signal that the override fired.)"""
+        results = manager.list()
+        _set_shared_results(results)
+
         pq.schedule(
-            slow_async_handler,
+            tracked_slow_async_handler,
             run_every=timedelta(seconds=60),
             max_runtime=0.1,
         )
         pq.run_worker_once(max_runtime=30)
-        # Periodic doesn't pop from pending_count; assert via the
-        # schedule's last_run timestamp moving forward.
-        from sqlalchemy import select
 
-        with pq.session() as session:
-            periodic = session.execute(select(Periodic)).scalar_one()
-            assert periodic.last_run is not None
+        assert list(results) == [], (
+            f"per-task max_runtime=0.1 should have killed the handler "
+            f"before its 10 s sleep finished; got results={list(results)}"
+        )
 
-    def test_periodic_task_falls_back_to_worker_default_when_null(self, pq: PQ) -> None:
-        """Backwards-compat for the periodic path."""
-        pq.schedule(slow_async_handler, run_every=timedelta(seconds=60))
-        pq.run_worker_once(max_runtime=0.1)  # worker default kills it
-        from sqlalchemy import select
+    def test_periodic_task_falls_back_to_worker_default_when_null(
+        self, pq: PQ, manager: multiprocessing.managers.SyncManager
+    ) -> None:
+        """Backwards-compat for the periodic path: NULL override means
+        the worker default applies. Worker default = 0.1 s here →
+        ``tracked_slow_async_handler``'s 10 s sleep never finishes →
+        marker never written."""
+        results = manager.list()
+        _set_shared_results(results)
 
-        with pq.session() as session:
-            periodic = session.execute(select(Periodic)).scalar_one()
-            assert periodic.last_run is not None
+        pq.schedule(tracked_slow_async_handler, run_every=timedelta(seconds=60))
+        pq.run_worker_once(max_runtime=0.1)
+
+        assert list(results) == [], (
+            f"worker default of 0.1 s should have killed the handler "
+            f"before its 10 s sleep finished; got results={list(results)}"
+        )
 
     def test_periodic_lock_duration_scales_with_per_task_max_runtime(
         self,


### PR DESCRIPTION
## Summary

Adds a nullable `max_runtime_seconds` column to both `pq_tasks` and `pq_periodic`, threaded through `Client.enqueue`, `Client.upsert`, and `Client.schedule` as an optional `max_runtime` float parameter. When `None` (the common case), existing behaviour is preserved exactly — workers use their configured default and the reaper uses its configured threshold. When set, that specific row gets:

- A per-execution wall-clock cap of the supplied value, enforced inside the forked child by the existing `signal.alarm` + `asyncio.wait_for` machinery — wired through all four task-execution paths (sequential / concurrent × one-off / periodic).
- A proportionally extended stale-reaper window of `max(default_threshold, max_runtime_seconds * 2)` per row, so a legitimately long task with a big declared budget isn't reaped before that budget × 2 elapses. Implemented with `GREATEST` + `COALESCE` in the reaper SQL so a heterogeneous batch still reaps in a single round-trip.
- For periodic schedules with `max_concurrent=1`, the `locked_until` window scales with the per-task value so the concurrency lock doesn't expire mid-execution.

## Why

pq's worker-level `max_runtime` is a fleet-wide policy. Fleets sized for typical short tasks (the common shape — web background work) can't host occasionally-long tasks (data exports, large reports, periodic deep-sync jobs) without either tightening every short task to the long task's tolerance or loosening the global default and giving up the short-task safety net. A per-task override resolves that without forcing either trade-off.

**Concrete motivation:** Cogram's data-export worker iterates thousands of meetings with LLM-rendered DOCX per row, runs ~hours at prod scale, and currently can't be hosted on the same worker pool as everything else because pq's 30-min default kills the build at 60 min (reaper) every time. With this override, the data_export task can declare `max_runtime=48 * 3600` (48 hours) without disturbing every other task that worker handles.

## Migration

Single Alembic revision (`aee3e8e7e647`) adds the column to both tables as nullable `Float` with no default and no backfill. Postgres 11+ treats this as a catalog-only operation (no table rewrite, brief `ACCESS EXCLUSIVE` lock on the system-catalog row, typically < 100 ms even on tables with millions of rows). Existing rows simply read NULL for the new column lazily.

Old enqueue / schedule call sites are unaffected — the new parameter defaults to `None`, which persists as NULL, which the worker treats as "use my configured default" (the prior behaviour).

## Tests

20 tests in the initial commit + 14 added in response to adversarial review (validation, concurrent-mode coverage, per-row error message). Full matrix:

- **Storage** (`TestMaxRuntimeOverridePersistence`) — enqueue, upsert, schedule each persist the value; NULL when omitted; upsert / schedule overwrite on conflict and can clear back to NULL.
- **Validation** (`TestMaxRuntimeOverrideValidation`) — `max_runtime <= 0` rejected by all three client methods with a clear `ValueError`; `0.001` accepted (boundary); `None` accepted (the "use worker default" contract).
- **Reaper SQL** (`TestReapStaleTasksRespectsPerTaskOverride`) — long per-task threshold protects a legitimately running task that the global threshold would have reaped; NULL falls back to the supplied default; the default acts as a floor so a tiny per-task value can't accidentally tighten the reaper window; a heterogeneous batch is reaped per-row, not all-or-nothing; the per-row `error` message names that row's own `max_runtime_seconds` and the effective threshold that fired.
- **Worker enforcement, sequential paths** (`TestPerTaskMaxRuntimeEnforcement`) — one-off + periodic × async + sync, plus fallback-to-default tests, plus a periodic lock-duration test that captures `locked_until` from inside the forked handler via shared multiprocessing state (the post-execution cleanup at `worker.py:833` clears the lock otherwise).
- **Worker enforcement, concurrent paths** (`TestConcurrentWorker`) — both one-off and periodic per-task overrides honoured under `_run_concurrent` mode. Closes the coverage gap the original PR had: the sequential and concurrent fork-claim paths are line-by-line identical but absence of explicit concurrent tests meant a regression on that side wouldn't be caught.
- **Migration safety** (`TestMigrationAppliesOnPopulatedTables`) — downgrades past the new revision, inserts rows under the old schema, upgrades again, asserts the seeded rows survive with NULL in the new column AND that the override is wired through enqueue post-upgrade. Wrapped in `try/finally` so a failed assertion doesn't leave the (shared) test database without the column.

Full suite: **165 passed** (131 pre-existing + 34 new). Typecheck (`ty`) and pre-commit (`ruff check` + `ruff format`) clean.

## Out of scope

- No per-task override for the `DEFAULT_MAX_RUNTIME` worker parameter itself (still affects the fleet-wide default).
- No version bump in `pyproject.toml` per `RELEASE.md` (releases handled by maintainer via `make release-*`).
- `signal.alarm` granularity floors `max_runtime` to integer seconds for sync handlers — pre-existing limitation, the validator accepts `0.001` but the SIGALRM safety-net rounds to 1 s for sync. Async handlers' `asyncio.wait_for` honours sub-second values precisely.

## Test plan

- [x] `uv run pytest tests/` — 165 passed
- [x] `uv run ty check` — clean
- [x] `uv run pre-commit run --all-files` — clean
- [ ] Reviewer's call on whether the reaper's `max(default, per_task * 2)` floor is the right semantic (vs. e.g. always-use-per-task) — happy to adjust if the project preference differs